### PR TITLE
Implement keyboard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ repositories {
 }
 
 dependencies {
+    compile 'commons-io:commons-io:2.5'
+    compile 'org.apache.commons:commons-lang3:3.6'
     compile 'com.beust:jcommander:1.72'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-all:1.10.19'

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Keyboard.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Keyboard.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright (C) 2017 Craig Thomas
+ * This project uses an MIT style license - see LICENSE for details.
+ */
+package ca.craigthomas.yacoco3e.components;
+
+import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
+import ca.craigthomas.yacoco3e.datatypes.UnsignedWord;
+
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+
+/**
+ * This class records key-presses on the emulated keyboard, and stores
+ * them in the correct memory locations for I/O routines.
+ *
+ * The keys on the COCO3 keyboard are as follows (symbols in brackets
+ * represent shifted values):
+ *
+ * 1(!)  2(")  3(#)  4($)  5(%)  6(&)  7(')  8(()  9())  0( )  :(*)  -(=)
+ * ALT   Q     W     E     R     T     Y     U     I     O     P     @
+ * CTRL  A     S     D     F     G     H     J     L     ;(+)  ENTER
+ * SHIFT Z     X     C     V     B     N     M     ,(<)  .(>)  /(?)  SHIFT
+ * UP    DOWN  LEFT  RIGHT F1    F2    BREAK ESC
+ *
+ * A single word is used to encode what keys are pressed. The HIGH byte of
+ * the word represents the ROW of the key in the table below. The LOW byte
+ * of the word represents the COLUMN of the key in the table below. To get
+ * the value of the keyboard, this keyboard word is available at memory
+ * addresses: FF00 (HIGH) and FF02 (LOW).
+ *
+ * HIGH
+ *   7
+ *   6   SHIFT   F2    F1   CTRL   ALT   BRK   CLR   ENTER
+ *   5     /     .     -     ,      ;     :     9      8
+ *   4     7     6     5     4      3     2     1      0
+ *   3   SPACE   RIGHT LEFT  DOW    UP    z     y      x
+ *   2     w     v     u     t      s     r     q      p
+ *   1     o     n     m     l      k     j     i      h
+ *   0     g     f     e     d      c     b     a      @
+ *
+ *         7     6     5     4      3     2     1      0
+ *                          LOW
+ */
+public class Keyboard extends KeyAdapter
+{
+    public final static UnsignedWord HIGH_BYTE = new UnsignedWord(0xFF00);
+    public final static UnsignedWord LOW_BYTE = new UnsignedWord(0xFF02);
+
+    private UnsignedByte highByte;
+    private UnsignedByte lowByte;
+    private Memory memory;
+
+    public Keyboard(Memory memory) {
+        super();
+        this.highByte = new UnsignedByte(0xFF);
+        this.lowByte = new UnsignedByte(0xFF);
+        this.memory = memory;
+    }
+
+    @Override
+    public void keyPressed(KeyEvent e) {
+        int keyPressed = e.getKeyCode();
+
+        switch (keyPressed) {
+
+            /* SHIFT */
+            case KeyEvent.VK_SHIFT:
+                highByte.or(0x40);
+                lowByte.or(0x80);
+                break;
+
+            /* F2 */
+            case KeyEvent.VK_F2:
+                highByte.or(0x40);
+                lowByte.or(0x40);
+                break;
+
+            /* F1 */
+            case KeyEvent.VK_F1:
+                highByte.or(0x40);
+                lowByte.or(0x20);
+                break;
+
+            /* CTRL */
+            case KeyEvent.VK_CONTROL:
+                highByte.or(0x40);
+                lowByte.or(0x10);
+                break;
+
+            /* ALT */
+            case KeyEvent.VK_ALT:
+                highByte.or(0x40);
+                lowByte.or(0x08);
+                break;
+
+            /* BREAK */
+            case KeyEvent.VK_ESCAPE:
+                highByte.or(0x40);
+                lowByte.or(0x04);
+                break;
+
+            /* CLR */
+            case KeyEvent.VK_HOME:
+                highByte.or(0x40);
+                lowByte.or(0x02);
+                break;
+
+            /* ENTER */
+            case KeyEvent.VK_ENTER:
+                highByte.or(0x40);
+                lowByte.or(0x01);
+                break;
+
+            /* / */
+            case KeyEvent.VK_SLASH:
+                highByte.or(0x20);
+                lowByte.or(0x80);
+                break;
+
+            /* . */
+            case KeyEvent.VK_PERIOD:
+                highByte.or(0x20);
+                lowByte.or(0x40);
+                break;
+
+            /* - */
+            case KeyEvent.VK_MINUS:
+                highByte.or(0x20);
+                lowByte.or(0x20);
+                break;
+
+            /* , */
+            case KeyEvent.VK_COMMA:
+                highByte.or(0x20);
+                lowByte.or(0x10);
+                break;
+
+            /* ; */
+            case KeyEvent.VK_SEMICOLON:
+                highByte.or(0x20);
+                lowByte.or(0x08);
+                break;
+
+            /* : */
+            case KeyEvent.VK_COLON:
+                highByte.or(0x20);
+                lowByte.or(0x04);
+                break;
+
+            /* 9 */
+            case KeyEvent.VK_9:
+                highByte.or(0x20);
+                lowByte.or(0x02);
+                break;
+
+            /* 8 */
+            case KeyEvent.VK_8:
+                highByte.or(0x20);
+                lowByte.or(0x01);
+                break;
+
+            /* 7 */
+            case KeyEvent.VK_7:
+                highByte.or(0x10);
+                lowByte.or(0x80);
+                break;
+
+            /* 6 */
+            case KeyEvent.VK_6:
+                highByte.or(0x10);
+                lowByte.or(0x40);
+                break;
+
+            /* 5 */
+            case KeyEvent.VK_5:
+                highByte.or(0x10);
+                lowByte.or(0x20);
+                break;
+
+            /* 4 */
+            case KeyEvent.VK_4:
+                highByte.or(0x10);
+                lowByte.or(0x10);
+                break;
+
+            /* 3 */
+            case KeyEvent.VK_3:
+                highByte.or(0x10);
+                lowByte.or(0x08);
+                break;
+
+            /* 2 */
+            case KeyEvent.VK_2:
+                highByte.or(0x10);
+                lowByte.or(0x04);
+                break;
+
+            /* 1 */
+            case KeyEvent.VK_1:
+                highByte.or(0x10);
+                lowByte.or(0x02);
+                break;
+
+            /* 0 */
+            case KeyEvent.VK_0:
+                highByte.or(0x10);
+                lowByte.or(0x01);
+                break;
+
+            /* SPACE */
+            case KeyEvent.VK_SPACE:
+                highByte.or(0x08);
+                lowByte.or(0x80);
+                break;
+
+            /* RIGHT ARROW */
+            case KeyEvent.VK_RIGHT:
+                highByte.or(0x08);
+                lowByte.or(0x40);
+                break;
+
+            /* LEFT ARROW */
+            case KeyEvent.VK_LEFT:
+                highByte.or(0x08);
+                lowByte.or(0x20);
+                break;
+
+            /* DOWN ARROW */
+            case KeyEvent.VK_DOWN:
+                highByte.or(0x08);
+                lowByte.or(0x10);
+                break;
+
+            /* UP ARROW */
+            case KeyEvent.VK_UP:
+                highByte.or(0x08);
+                lowByte.or(0x08);
+                break;
+
+            /* Z */
+            case KeyEvent.VK_Z:
+                highByte.or(0x08);
+                lowByte.or(0x04);
+                break;
+
+            /* Y */
+            case KeyEvent.VK_Y:
+                highByte.or(0x08);
+                lowByte.or(0x02);
+                break;
+
+            /* X */
+            case KeyEvent.VK_X:
+                highByte.or(0x08);
+                lowByte.or(0x01);
+                break;
+
+            /* W */
+            case KeyEvent.VK_W:
+                highByte.or(0x04);
+                lowByte.or(0x80);
+                break;
+
+            /* V */
+            case KeyEvent.VK_V:
+                highByte.or(0x04);
+                lowByte.or(0x40);
+                break;
+
+            /* U */
+            case KeyEvent.VK_U:
+                highByte.or(0x04);
+                lowByte.or(0x20);
+                break;
+
+            /* T */
+            case KeyEvent.VK_T:
+                highByte.or(0x04);
+                lowByte.or(0x10);
+                break;
+
+            /* S */
+            case KeyEvent.VK_S:
+                highByte.or(0x04);
+                lowByte.or(0x08);
+                break;
+
+            /* R */
+            case KeyEvent.VK_R:
+                highByte.or(0x04);
+                lowByte.or(0x04);
+                break;
+
+            /* Q */
+            case KeyEvent.VK_Q:
+                highByte.or(0x04);
+                lowByte.or(0x02);
+                break;
+
+            /* P */
+            case KeyEvent.VK_P:
+                highByte.or(0x04);
+                lowByte.or(0x01);
+                break;
+
+            /* O */
+            case KeyEvent.VK_O:
+                highByte.or(0x02);
+                lowByte.or(0x80);
+                break;
+
+            /* N */
+            case KeyEvent.VK_N:
+                highByte.or(0x02);
+                lowByte.or(0x40);
+                break;
+
+            /* M */
+            case KeyEvent.VK_M:
+                highByte.or(0x02);
+                lowByte.or(0x20);
+                break;
+
+            /* L */
+            case KeyEvent.VK_L:
+                highByte.or(0x02);
+                lowByte.or(0x10);
+                break;
+
+            /* K */
+            case KeyEvent.VK_K:
+                highByte.or(0x02);
+                lowByte.or(0x08);
+                break;
+
+            /* J */
+            case KeyEvent.VK_J:
+                highByte.or(0x02);
+                lowByte.or(0x04);
+                break;
+
+            /* I */
+            case KeyEvent.VK_I:
+                highByte.or(0x02);
+                lowByte.or(0x02);
+                break;
+
+            /* H */
+            case KeyEvent.VK_H:
+                highByte.or(0x02);
+                lowByte.or(0x01);
+                break;
+
+            /* G */
+            case KeyEvent.VK_G:
+                highByte.or(0x01);
+                lowByte.or(0x80);
+                break;
+
+            /* F */
+            case KeyEvent.VK_F:
+                highByte.or(0x01);
+                lowByte.or(0x40);
+                break;
+
+            /* E */
+            case KeyEvent.VK_E:
+                highByte.or(0x01);
+                lowByte.or(0x20);
+                break;
+
+            /* D */
+            case KeyEvent.VK_D:
+                highByte.or(0x01);
+                lowByte.or(0x10);
+                break;
+
+            /* C */
+            case KeyEvent.VK_C:
+                highByte.or(0x01);
+                lowByte.or(0x08);
+                break;
+
+            /* B */
+            case KeyEvent.VK_B:
+                highByte.or(0x01);
+                lowByte.or(0x04);
+                break;
+
+            /* A */
+            case KeyEvent.VK_A:
+                highByte.or(0x01);
+                lowByte.or(0x02);
+                break;
+
+            /* @ */
+            case KeyEvent.VK_ASTERISK:
+                highByte.or(0x01);
+                lowByte.or(0x01);
+                break;
+        }
+        writeToMemory();
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e) {
+        highByte.and(0x0);
+        lowByte.and(0x0);
+        writeToMemory();
+    }
+
+    /**
+     * Writes the current value of the high and low bytes into the
+     * proper memory locations. The values written to memory require
+     * an active low value, so the inverse bit patterns are written.
+     */
+    public void writeToMemory() {
+        memory.writeByte(HIGH_BYTE, highByte.inverse());
+        memory.writeByte(LOW_BYTE, lowByte.inverse());
+    }
+}

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Screen.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Screen.java
@@ -954,10 +954,10 @@ public class Screen
             }
     };
 
-    public Screen(Memory memory) {
+    public Screen(Memory memory, int scale) {
         this.width = SG4_WIDTH;
         this.height = SG4_HEIGHT;
-        this.scale = 2;
+        this.scale = scale;
         this.screenMode = ScreenMode.SEMIGRAPHICS4;
         this.foreColor = 0;
         this.backColor = 8;
@@ -1056,6 +1056,9 @@ public class Screen
         int x = 32 + (col * 8);
         int y = 25 + (row * 12);
         int intValue = value.getShort();
+        if (intValue > 128) {
+            intValue = 0;
+        }
         int character = intValue > SG4_CHARACTERS.length ?
                 intValue - SG4_CHARACTERS.length : intValue;
         boolean inverse = value.getShort() < SG4_CHARACTERS.length;

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/MemoryResult.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/MemoryResult.java
@@ -16,6 +16,10 @@ public class MemoryResult
     /* The result of the memory operation */
     UnsignedWord result;
 
+    public MemoryResult() {
+        this(0, new UnsignedWord());
+    }
+
     public MemoryResult(int bytesConsumed, UnsignedWord result) {
         this.bytesConsumed = bytesConsumed;
         this.result = result;

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/RegisterSet.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/RegisterSet.java
@@ -62,11 +62,11 @@ public class RegisterSet
     }
 
     public void setPC(UnsignedWord pc) {
-        this.pc = pc;
+        this.pc = pc.copy();
     }
 
     public void setDP(UnsignedByte dp) {
-        this.dp = dp;
+        this.dp = dp.copy();
     }
 
     public UnsignedByte getDP() {
@@ -90,31 +90,31 @@ public class RegisterSet
     }
 
     public void setA(UnsignedByte a) {
-        this.a = a;
+        this.a = a.copy();
     }
 
     public void setB(UnsignedByte b) {
-        this.b = b;
+        this.b = b.copy();
     }
 
     public void setCC(UnsignedByte cc) {
-        this.cc = cc;
+        this.cc = cc.copy();
     }
 
     public void setX(UnsignedWord x) {
-        this.x = x;
+        this.x = x.copy();
     }
 
     public void setY(UnsignedWord y) {
-        this.y = y;
+        this.y = y.copy();
     }
 
     public void setU(UnsignedWord u) {
-        this.u = u;
+        this.u = u.copy();
     }
 
     public void setS(UnsignedWord s) {
-        this.s = s;
+        this.s = s.copy();
     }
 
     /**

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedByte.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedByte.java
@@ -55,6 +55,14 @@ public class UnsignedByte
     }
 
     /**
+     * Returns the inverse bit value of the byte.
+     *
+     * @return the inverse bit value of the byte
+     */
+    public UnsignedByte inverse() {
+        return new UnsignedByte(~value);
+    }
+    /**
      * Returns true if the specified mask results in a non-zero value when
      * ANDed to the current value of the byte.
      *

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedWord.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedWord.java
@@ -95,6 +95,15 @@ public class UnsignedWord
     }
 
     /**
+     * Returns the inverse bit value of the UnsignedWord.
+     *
+     * @return the inverse bit value of the word
+     */
+    public UnsignedWord inverse() {
+        return new UnsignedWord(~value);
+    }
+
+    /**
      * Applies the specified mask using an AND operation.
      *
      * @param mask the mask to apply

--- a/src/main/java/ca/craigthomas/yacoco3e/listeners/QuitMenuItemActionListener.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/listeners/QuitMenuItemActionListener.java
@@ -1,5 +1,7 @@
 package ca.craigthomas.yacoco3e.listeners;
 
+import ca.craigthomas.yacoco3e.components.CPU;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -10,8 +12,11 @@ import java.awt.event.ActionListener;
  */
 public class QuitMenuItemActionListener implements ActionListener
 {
-    public QuitMenuItemActionListener() {
+    private CPU cpu;
+
+    public QuitMenuItemActionListener(CPU cpu) {
         super();
+        this.cpu = cpu;
     }
 
     @Override
@@ -23,6 +28,7 @@ public class QuitMenuItemActionListener implements ActionListener
                 JOptionPane.OK_CANCEL_OPTION
         );
         if (result == JOptionPane.OK_OPTION) {
+            cpu.kill();
             System.exit(0);
         }
     }

--- a/src/main/java/ca/craigthomas/yacoco3e/runner/Arguments.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/runner/Arguments.java
@@ -6,9 +6,12 @@ package ca.craigthomas.yacoco3e.runner;
 
 import com.beust.jcommander.Parameter;
 
+/**
+ * A data class that stores the arguments that may be passed to the emulator.
+ */
 public class Arguments
 {
-    @Parameter(names="--rom", description="ROM file")
+    @Parameter(description="ROM file")
     public String romFile;
 
     @Parameter(names="--scale", description="scale factor")

--- a/src/main/java/ca/craigthomas/yacoco3e/runner/Runner.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/runner/Runner.java
@@ -15,8 +15,9 @@ public class Runner
                 .addObject(arguments)
                 .build();
         jCommander.setProgramName("yacoco3e");
+        jCommander.parse(argv);
 
-        Emulator emulator = new Emulator(arguments.scale.intValue());
+        Emulator emulator = new Emulator(arguments.scale, arguments.romFile);
         emulator.start();
     }
 }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CPUIntegrationTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CPUIntegrationTest.java
@@ -30,6 +30,10 @@ public class CPUIntegrationTest
 
     private UnsignedByte expectedDirectByte;
 
+    private UnsignedWord extendedAddress;
+    private UnsignedByte expectedExtendedByte;
+    private UnsignedWord expectedExtendedWord;
+
     @Before
     public void setUp() {
         memory = new Memory();
@@ -44,6 +48,11 @@ public class CPUIntegrationTest
         registerSetSpy.setDP(new UnsignedByte(0xA0));
         expectedDirectByte = new UnsignedByte(0xBA);
         memorySpy.writeByte(new UnsignedWord(0xA000), new UnsignedByte(0xBA));
+
+        extendedAddress = new UnsignedWord(0xC0A0);
+        expectedExtendedByte = new UnsignedByte(0xCF);
+        expectedExtendedWord = new UnsignedWord(0xCFDA);
+        memorySpy.writeWord(extendedAddress, expectedExtendedWord);
     }
 
     @Test
@@ -65,9 +74,10 @@ public class CPUIntegrationTest
     @Test
     public void testNegateExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x70));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).negate(new UnsignedByte(0));
+        verify(cpuSpy).negate(expectedExtendedByte);
     }
 
     @Test
@@ -89,9 +99,10 @@ public class CPUIntegrationTest
     @Test
     public void testComplementExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x73));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).compliment(new UnsignedByte(0));
+        verify(cpuSpy).compliment(expectedExtendedByte);
     }
 
     @Test
@@ -113,9 +124,10 @@ public class CPUIntegrationTest
     @Test
     public void testLogicalShiftRightExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x74));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).logicalShiftRight(new UnsignedByte(0));
+        verify(cpuSpy).logicalShiftRight(expectedExtendedByte);
     }
 
     @Test
@@ -137,9 +149,10 @@ public class CPUIntegrationTest
     @Test
     public void testRotateRightExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x76));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).rotateRight(new UnsignedByte(0));
+        verify(cpuSpy).rotateRight(expectedExtendedByte);
     }
 
     @Test
@@ -161,9 +174,10 @@ public class CPUIntegrationTest
     @Test
     public void testArithmeticShiftRightExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x77));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).arithmeticShiftRight(new UnsignedByte(0));
+        verify(cpuSpy).arithmeticShiftRight(expectedExtendedByte);
     }
 
     @Test
@@ -185,9 +199,10 @@ public class CPUIntegrationTest
     @Test
     public void testArithmeticShiftLeftExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x78));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).arithmeticShiftLeft(new UnsignedByte(0));
+        verify(cpuSpy).arithmeticShiftLeft(expectedExtendedByte);
     }
 
     @Test
@@ -209,9 +224,10 @@ public class CPUIntegrationTest
     @Test
     public void testRotateLeftExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x79));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).rotateLeft(new UnsignedByte(0));
+        verify(cpuSpy).rotateLeft(expectedExtendedByte);
     }
 
     @Test
@@ -233,9 +249,10 @@ public class CPUIntegrationTest
     @Test
     public void testDecrementExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x7A));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).decrement(new UnsignedByte(0));
+        verify(cpuSpy).decrement(expectedExtendedByte);
     }
 
     @Test
@@ -257,9 +274,10 @@ public class CPUIntegrationTest
     @Test
     public void testIncrementExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x7C));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).increment(new UnsignedByte(0));
+        verify(cpuSpy).increment(expectedExtendedByte);
     }
 
     @Test
@@ -281,9 +299,10 @@ public class CPUIntegrationTest
     @Test
     public void testTestExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x7D));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).test(new UnsignedByte(0));
+        verify(cpuSpy).test(expectedExtendedByte);
     }
 
     @Test
@@ -305,9 +324,10 @@ public class CPUIntegrationTest
     @Test
     public void testJumpExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x7E));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).jump(new UnsignedWord(0x7E00));
+        verify(cpuSpy).jump(expectedExtendedWord);
     }
 
     @Test
@@ -329,9 +349,10 @@ public class CPUIntegrationTest
     @Test
     public void testClearExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0x7F));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).clear(new UnsignedByte(0));
+        verify(cpuSpy).clear(expectedExtendedByte);
     }
 
     @Test
@@ -346,7 +367,7 @@ public class CPUIntegrationTest
     public void testLongBranchNeverDoesNothing() {
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x1021));
         cpuSpy.executeInstruction();
-        assertEquals(0x2, registerSet.getPC().getInt());
+        assertEquals(0x4, registerSet.getPC().getInt());
         verify(cpuSpy, never()).branchLong(new UnsignedWord(0x0000));
     }
 
@@ -795,9 +816,10 @@ public class CPUIntegrationTest
     public void testCompareDExtendedCalled() {
         registerSetSpy.setD(new UnsignedWord(0x10));
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x10B3));
+        memorySpy.writeWord(new UnsignedWord(0x2), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).compareWord(new UnsignedWord(0x10), new UnsignedWord(0x00));
+        verify(cpuSpy).compareWord(new UnsignedWord(0x10), expectedExtendedWord);
     }
 
     @Test
@@ -830,9 +852,10 @@ public class CPUIntegrationTest
     public void testCompareUExtendedCalled() {
         registerSetSpy.setU(new UnsignedWord(0x10));
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x11B3));
+        memorySpy.writeWord(new UnsignedWord(0x2), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).compareWord(new UnsignedWord(0x10), new UnsignedWord(0x00));
+        verify(cpuSpy).compareWord(new UnsignedWord(0x10), expectedExtendedWord);
     }
 
     @Test
@@ -865,9 +888,10 @@ public class CPUIntegrationTest
     public void testCompareYExtendedCalled() {
         registerSetSpy.setY(new UnsignedWord(0x10));
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x10BC));
+        memorySpy.writeWord(new UnsignedWord(0x2), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).compareWord(new UnsignedWord(0x10), new UnsignedWord(0x00));
+        verify(cpuSpy).compareWord(new UnsignedWord(0x10), expectedExtendedWord);
     }
 
     @Test
@@ -900,9 +924,10 @@ public class CPUIntegrationTest
     public void testCompareSExtendedCalled() {
         registerSetSpy.setS(new UnsignedWord(0x10));
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x11BC));
+        memorySpy.writeWord(new UnsignedWord(0x2), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).compareWord(new UnsignedWord(0x10), new UnsignedWord(0x00));
+        verify(cpuSpy).compareWord(new UnsignedWord(0x10), expectedExtendedWord);
     }
 
     @Test
@@ -934,10 +959,11 @@ public class CPUIntegrationTest
     @Test
     public void testCompareXExtendedCalled() {
         registerSetSpy.setX(new UnsignedWord(0x10));
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xBC00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xBC));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).compareWord(new UnsignedWord(0x10), new UnsignedWord(0x00));
+        verify(cpuSpy).compareWord(new UnsignedWord(0x10), expectedExtendedWord);
     }
 
     @Test
@@ -968,9 +994,10 @@ public class CPUIntegrationTest
     @Test
     public void testLoadYExtendedCalled() {
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x10BE));
+        memorySpy.writeWord(new UnsignedWord(0x2), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).loadRegister(Register.Y, new UnsignedWord());
+        verify(cpuSpy).loadRegister(Register.Y, expectedExtendedWord);
     }
 
     @Test
@@ -1001,9 +1028,10 @@ public class CPUIntegrationTest
     @Test
     public void testLoadSExtendedCalled() {
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x10FE));
+        memorySpy.writeWord(new UnsignedWord(0x2), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).loadRegister(Register.S, new UnsignedWord());
+        verify(cpuSpy).loadRegister(Register.S, expectedExtendedWord);
     }
 
     @Test
@@ -1033,10 +1061,11 @@ public class CPUIntegrationTest
 
     @Test
     public void testLoadXExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xBE00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xBE));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).loadRegister(Register.X, new UnsignedWord(0xBE00));
+        verify(cpuSpy).loadRegister(Register.X, expectedExtendedWord);
     }
 
     @Test
@@ -1058,9 +1087,10 @@ public class CPUIntegrationTest
     @Test
     public void testStoreYExtendedCalled() {
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x10BF));
+        memorySpy.writeWord(new UnsignedWord(0x2), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).storeWordRegister(Register.Y, new UnsignedWord());
+        verify(cpuSpy).storeWordRegister(Register.Y, expectedExtendedWord);
     }
 
     @Test
@@ -1081,10 +1111,11 @@ public class CPUIntegrationTest
 
     @Test
     public void testStoreXExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xBF00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xBF));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).storeWordRegister(Register.X, new UnsignedWord(0xBF00));
+        verify(cpuSpy).storeWordRegister(Register.X, expectedExtendedWord);
     }
 
     @Test
@@ -1106,9 +1137,10 @@ public class CPUIntegrationTest
     @Test
     public void testStoreSExtendedCalled() {
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x10FF));
+        memorySpy.writeWord(new UnsignedWord(0x2), extendedAddress);
         cpuSpy.executeInstruction();
         verify(memorySpy).getExtended(registerSetSpy);
-        verify(cpuSpy).storeWordRegister(Register.S, new UnsignedWord());
+        verify(cpuSpy).storeWordRegister(Register.S, expectedExtendedWord);
     }
 
     @Test
@@ -1451,7 +1483,8 @@ public class CPUIntegrationTest
         registerSetSpy.setD(new UnsignedWord(0xBEEF));
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x1F50));
         cpuSpy.executeInstruction();
-        assertEquals(new UnsignedWord(0x0001), registerSetSpy.getPC());
+        /* PC will have advanced */
+        assertEquals(new UnsignedWord(0x0002), registerSetSpy.getPC());
         assertEquals(new UnsignedWord(0x0001), registerSetSpy.getD());
     }
 
@@ -1529,7 +1562,8 @@ public class CPUIntegrationTest
         registerSetSpy.setX(new UnsignedWord(0xBEEF));
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x1F51));
         cpuSpy.executeInstruction();
-        assertEquals(new UnsignedWord(0x0001), registerSetSpy.getPC());
+        /* PC will have advanced */
+        assertEquals(new UnsignedWord(0x0002), registerSetSpy.getPC());
         assertEquals(new UnsignedWord(0x0001), registerSetSpy.getX());
     }
 
@@ -1587,7 +1621,8 @@ public class CPUIntegrationTest
         registerSetSpy.setY(new UnsignedWord(0xBEEF));
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x1F52));
         cpuSpy.executeInstruction();
-        assertEquals(new UnsignedWord(0x0001), registerSetSpy.getPC());
+        /* PC will have advanced */
+        assertEquals(new UnsignedWord(0x0002), registerSetSpy.getPC());
         assertEquals(new UnsignedWord(0x0001), registerSetSpy.getY());
     }
 
@@ -1625,7 +1660,8 @@ public class CPUIntegrationTest
         registerSetSpy.setU(new UnsignedWord(0xBEEF));
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x1F53));
         cpuSpy.executeInstruction();
-        assertEquals(new UnsignedWord(0x0001), registerSetSpy.getPC());
+        /* PC will have advanced */
+        assertEquals(new UnsignedWord(0x0002), registerSetSpy.getPC());
         assertEquals(new UnsignedWord(0x0001), registerSetSpy.getU());
     }
 
@@ -1643,7 +1679,8 @@ public class CPUIntegrationTest
         registerSetSpy.setS(new UnsignedWord(0xBEEF));
         memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0x1F54));
         cpuSpy.executeInstruction();
-        assertEquals(new UnsignedWord(0x0001), registerSetSpy.getPC());
+        /* PC will have advanced */
+        assertEquals(new UnsignedWord(0x0002), registerSetSpy.getPC());
         assertEquals(new UnsignedWord(0x0001), registerSetSpy.getS());
     }
 
@@ -2479,24 +2516,26 @@ public class CPUIntegrationTest
     @Test
     public void testSubtractMAExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB0));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).subtractM(Register.A, new UnsignedByte(0x00));
+        verify(cpuSpy).subtractM(Register.A, expectedExtendedByte);
     }
 
     @Test
     public void testCompareAExtendedCalled() {
         registerSetSpy.setA(new UnsignedByte(0xBE));
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB1));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).compareByte(new UnsignedByte(0xBE), new UnsignedByte(0x0));
+        verify(cpuSpy).compareByte(new UnsignedByte(0xBE), expectedExtendedByte);
     }
 
     @Test
     public void testSubtractMCAExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB2));
-        memorySpy.writeWord(new UnsignedWord(0x1), new UnsignedWord(0xBEEF));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).subtractMC(Register.A, new UnsignedByte(0x0));
+        verify(cpuSpy).subtractMC(Register.A, expectedExtendedByte);
     }
 
     @Test
@@ -2568,24 +2607,26 @@ public class CPUIntegrationTest
     @Test
     public void testSubtractMBExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF0));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).subtractM(Register.B, new UnsignedByte(0x00));
+        verify(cpuSpy).subtractM(Register.B, expectedExtendedByte);
     }
 
     @Test
     public void testCompareBExtendedCalled() {
         registerSetSpy.setB(new UnsignedByte(0xBE));
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF1));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).compareByte(new UnsignedByte(0xBE), new UnsignedByte(0x0));
+        verify(cpuSpy).compareByte(new UnsignedByte(0xBE), expectedExtendedByte);
     }
 
     @Test
     public void testSubtractMCBExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF2));
-        memorySpy.writeWord(new UnsignedWord(0x1), new UnsignedWord(0xBEEF));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).subtractMC(Register.B, new UnsignedByte(0xF2));
+        verify(cpuSpy).subtractMC(Register.B, expectedExtendedByte);
     }
 
     @Test
@@ -2615,8 +2656,9 @@ public class CPUIntegrationTest
     @Test
     public void testSubtractDExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB3));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).subtractD(new UnsignedWord(0x0));
+        verify(cpuSpy).subtractD(expectedExtendedWord);
     }
 
     @Test
@@ -2645,8 +2687,9 @@ public class CPUIntegrationTest
     @Test
     public void testLogicalAndAExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB4));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).logicalAnd(Register.A, new UnsignedByte(0x0));
+        verify(cpuSpy).logicalAnd(Register.A, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2676,8 +2719,9 @@ public class CPUIntegrationTest
     @Test
     public void testLogicalAndBExtendedCalled() {
         memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF4));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).logicalAnd(Register.B, new UnsignedByte(0x0));
+        verify(cpuSpy).logicalAnd(Register.B, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2708,9 +2752,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testTestAExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xB500));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB5));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).test(new UnsignedByte(0x0));
+        verify(cpuSpy).test(new UnsignedByte(registerSetSpy.getA().getShort() & expectedExtendedByte.getShort()));
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2741,9 +2786,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testTestBExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xF500));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF5));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).test(new UnsignedByte(0x0));
+        verify(cpuSpy).test(new UnsignedByte(registerSetSpy.getB().getShort() & expectedExtendedByte.getShort()));
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2772,9 +2818,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testLoadAExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xB600));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB6));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).loadByteRegister(Register.A, new UnsignedByte(0x0));
+        verify(cpuSpy).loadByteRegister(Register.A, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2803,9 +2850,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testLoadBExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xF600));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF6));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).loadByteRegister(Register.B, new UnsignedByte(0x0));
+        verify(cpuSpy).loadByteRegister(Register.B, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2835,9 +2883,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testLoadDExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xFC00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xFC));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).loadRegister(Register.D, new UnsignedWord(0x0));
+        verify(cpuSpy).loadRegister(Register.D, expectedExtendedWord);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2867,9 +2916,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testLoadUExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xFE00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xFE));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).loadRegister(Register.U, new UnsignedWord(0x0));
+        verify(cpuSpy).loadRegister(Register.U, expectedExtendedWord);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2898,9 +2948,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testEORAExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xB800));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB8));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).exclusiveOr(Register.A, new UnsignedByte(0x0));
+        verify(cpuSpy).exclusiveOr(Register.A, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2929,9 +2980,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testEORBExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xF800));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF8));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).exclusiveOr(Register.B, new UnsignedByte(0x0));
+        verify(cpuSpy).exclusiveOr(Register.B, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2960,9 +3012,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testADCAExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xB900));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB9));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).addWithCarry(Register.A, new UnsignedByte(0x0));
+        verify(cpuSpy).addWithCarry(Register.A, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -2991,9 +3044,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testADCBExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xF900));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF9));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).addWithCarry(Register.B, new UnsignedByte(0x0));
+        verify(cpuSpy).addWithCarry(Register.B, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3022,9 +3076,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testORAExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xBA00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xBA));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).logicalOr(Register.A, new UnsignedByte(0x0));
+        verify(cpuSpy).logicalOr(Register.A, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3053,9 +3108,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testORBExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xFA00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xFA));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).logicalOr(Register.B, new UnsignedByte(0x0));
+        verify(cpuSpy).logicalOr(Register.B, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3077,9 +3133,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testSTAExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xB700));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xB7));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).storeByteRegister(Register.A, new UnsignedWord(0xB700));
+        verify(cpuSpy).storeByteRegister(Register.A, extendedAddress);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3101,9 +3158,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testSTBExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xF700));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF7));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).storeByteRegister(Register.B, new UnsignedWord(0xF700));
+        verify(cpuSpy).storeByteRegister(Register.B, extendedAddress);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3125,9 +3183,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testJSRExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xBD00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xBD));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).jumpToSubroutine(new UnsignedWord(0xBD00));
+        verify(cpuSpy).jumpToSubroutine(expectedExtendedWord);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3149,9 +3208,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testSTDExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xFD00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xFD));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).storeWordRegister(Register.D, new UnsignedWord(0xFD00));
+        verify(cpuSpy).storeWordRegister(Register.D, expectedExtendedWord);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3173,9 +3233,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testSTUExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xFF00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xFF));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).storeWordRegister(Register.U, new UnsignedWord(0xFF00));
+        verify(cpuSpy).storeWordRegister(Register.U, expectedExtendedWord);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3197,9 +3258,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testADDDExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xF300));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xF3));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).addD(new UnsignedWord(0x0000));
+        verify(cpuSpy).addD(expectedExtendedWord);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3228,9 +3290,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testADDAExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xBB00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xBB));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).addByteRegister(Register.A, new UnsignedByte(0x0));
+        verify(cpuSpy).addByteRegister(Register.A, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 
@@ -3259,9 +3322,10 @@ public class CPUIntegrationTest
 
     @Test
     public void testADDBExtendedCalled() {
-        memorySpy.writeWord(new UnsignedWord(0x0), new UnsignedWord(0xFB00));
+        memorySpy.writeByte(new UnsignedWord(0x0), new UnsignedByte(0xFB));
+        memorySpy.writeWord(new UnsignedWord(0x1), extendedAddress);
         cpuSpy.executeInstruction();
-        verify(cpuSpy).addByteRegister(Register.B, new UnsignedByte(0x0));
+        verify(cpuSpy).addByteRegister(Register.B, expectedExtendedByte);
         verify(memorySpy).getExtended(registerSetSpy);
     }
 }


### PR DESCRIPTION
This PR introduces a keyboard into the emulator. Key events are intercepted and encoded into their CoCo 3 equivalents. Encoded keypresses are then written into their respective IO addresses of $FF00 and $FF02. In addition to the keyboard, the main emulator Runner is implemented, along with a main CPU loop.