### PR TITLE
Keyboard / IO Controller integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## What Is It?
 
-This project is a Color Computer 3 emulator written in C. Note that I cannot 
+This project is a Color Computer 3 emulator written in Java. Note that I cannot 
 distribute ROM files with the emulator, as they are copyright their 
 respective owners.
 

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
@@ -39,8 +39,8 @@ public class Emulator
 
     public Emulator(int scaleFactor, String romFile) {
         memory = new Memory();
-        ioController = new IOController(memory, new RegisterSet());
-        keyboard = new Keyboard(memory);
+        keyboard = new Keyboard();
+        ioController = new IOController(memory, new RegisterSet(), keyboard);
         screen = new Screen(ioController, scaleFactor);
         cpu = new CPU(ioController);
         screen.sg4ClearScreen();

--- a/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
@@ -16,6 +16,7 @@ public class IOController
 
     protected Memory memory;
     protected RegisterSet regs;
+    protected Keyboard keyboard;
 
     /* Condition Code - Carry */
     public static final short CC_C = 0x01;
@@ -41,10 +42,11 @@ public class IOController
     /* Condition Code - Everything */
     public static final short CC_E = 0x80;
 
-    public IOController(Memory memory, RegisterSet registerSet) {
+    public IOController(Memory memory, RegisterSet registerSet, Keyboard keyboard) {
         ioMemory = new short[IO_ADDRESS_SIZE];
         this.memory = memory;
         this.regs = registerSet;
+        this.keyboard = keyboard;
     }
 
     /**
@@ -68,6 +70,16 @@ public class IOController
      * @return the IO byte read
      */
     public UnsignedByte readIOByte(int address) {
+        switch (address) {
+            /* Keyboard High Byte */
+            case 0xFF00:
+                return keyboard.getHighByte();
+
+            /* Keyboard Low Byte */
+            case 0xFF02:
+                return keyboard.getLowByte();
+        }
+
         return new UnsignedByte(ioMemory[address - 0xFF00]);
     }
 

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Keyboard.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Keyboard.java
@@ -41,21 +41,19 @@ import java.awt.event.KeyEvent;
  *
  *         7     6     5     4      3     2     1      0
  *                          LOW
+ *
+ *  The keypresses on the CoCo are recorded as active low values, therefore
+ *  the byte values are inversed.
  */
 public class Keyboard extends KeyAdapter
 {
-    public final static UnsignedWord HIGH_BYTE = new UnsignedWord(0xFF00);
-    public final static UnsignedWord LOW_BYTE = new UnsignedWord(0xFF02);
-
     private UnsignedByte highByte;
     private UnsignedByte lowByte;
-    private Memory memory;
 
-    public Keyboard(Memory memory) {
+    public Keyboard() {
         super();
-        this.highByte = new UnsignedByte(0xFF);
-        this.lowByte = new UnsignedByte(0xFF);
-        this.memory = memory;
+        this.highByte = new UnsignedByte(0x0);
+        this.lowByte = new UnsignedByte(0x0);
     }
 
     @Override
@@ -395,28 +393,34 @@ public class Keyboard extends KeyAdapter
                 break;
 
             /* @ */
-            case KeyEvent.VK_ASTERISK:
+            case KeyEvent.VK_AT:
                 highByte.or(0x01);
                 lowByte.or(0x01);
                 break;
         }
-        writeToMemory();
     }
 
     @Override
     public void keyReleased(KeyEvent e) {
         highByte.and(0x0);
         lowByte.and(0x0);
-        writeToMemory();
     }
 
     /**
-     * Writes the current value of the high and low bytes into the
-     * proper memory locations. The values written to memory require
-     * an active low value, so the inverse bit patterns are written.
+     * Return the high byte from the keyboard.
+     *
+     * @return the high byte of the keyboard
      */
-    public void writeToMemory() {
-        memory.writeByte(HIGH_BYTE, highByte.inverse());
-        memory.writeByte(LOW_BYTE, lowByte.inverse());
+    public UnsignedByte getHighByte() {
+        return highByte.inverse();
+    }
+
+    /**
+     * Return the low byte of the keyboard.
+     *
+     * @return the low byte of the keyboard
+     */
+    public UnsignedByte getLowByte() {
+        return lowByte.inverse();
     }
 }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CPUIntegrationTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CPUIntegrationTest.java
@@ -45,7 +45,7 @@ public class CPUIntegrationTest
         registerSet = new RegisterSet();
         registerSetSpy = spy(registerSet);
 
-        io = new IOController(memorySpy, registerSetSpy);
+        io = new IOController(memorySpy, registerSetSpy, new Keyboard());
         ioSpy = spy(io);
 
         cpu = new CPU(ioSpy);

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
@@ -24,7 +24,7 @@ public class CPUTest
     public void setUp() {
         memory = new Memory();
         registerSet = new RegisterSet();
-        io = new IOController(memory, registerSet);
+        io = new IOController(memory, registerSet, new Keyboard());
         cpu = new CPU(io);
     }
 

--- a/src/test/java/ca/craigthomas/yacoco3e/components/KeyboardTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/KeyboardTest.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright (C) 2017 Craig Thomas
+ * This project uses an MIT style license - see LICENSE for details.
+ */
+package ca.craigthomas.yacoco3e.components;
+
+import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.awt.event.KeyEvent;
+
+import static org.junit.Assert.assertEquals;
+
+public class KeyboardTest
+{
+    private Keyboard keyboard;
+    private KeyEvent event;
+
+    @Before
+    public void setUp() {
+        event = Mockito.mock(KeyEvent.class);
+        keyboard = new Keyboard();
+    }
+
+    @Test
+    public void testKeyboardKeyPressShift() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_SHIFT);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0x7F), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressF2() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_F2);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xBF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressF1() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_F1);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xDF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressCTRL() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_CONTROL);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xEF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressALT() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_ALT);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xF7), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressESC() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_ESCAPE);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFB), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressHOME() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_HOME);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFD), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressENTER() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_ENTER);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFE), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressSlash() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_SLASH);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0x7F), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressPeriod() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_PERIOD);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xBF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyMinus() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_MINUS);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xDF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressComma() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_COMMA);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xEF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressSemicolon() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_SEMICOLON);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xF7), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressColon() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_COLON);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFB), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress9() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_9);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFD), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress8() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_8);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFE), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress7() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_7);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0x7F), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress6() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_6);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xBF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress5() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_5);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xDF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress4() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_4);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xEF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress3() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_3);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xF7), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress2() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_2);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFB), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress1() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_1);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFD), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPress0() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_0);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFE), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressSpace() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_SPACE);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xF7), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0x7F), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressRight() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_RIGHT);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xF7), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xBF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressLeft() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_LEFT);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xF7), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xDF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressDown() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_DOWN);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xF7), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xEF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressUp() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_UP);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xF7), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xF7), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressZ() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_Z);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xF7), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFB), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressY() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_Y);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xF7), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFD), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressX() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_X);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xF7), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFE), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressW() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_W);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0x7F), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressV() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_V);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xBF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressU() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_U);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xDF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressT() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_T);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xEF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressS() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_S);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xF7), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressR() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_R);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFB), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressQ() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_Q);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFD), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressP() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_P);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFE), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressO() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_O);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFD), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0x7F), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressN() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_N);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFD), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xBF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressM() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_M);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFD), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xDF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressL() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_L);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFD), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xEF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressK() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_K);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFD), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xF7), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressJ() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_J);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFD), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFB), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressI() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_I);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFD), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFD), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressH() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_P);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFE), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressG() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_G);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFE), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0x7F), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressF() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_F);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFE), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xBF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressE() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_E);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFE), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xDF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressD() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_D);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFE), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xEF), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressC() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_C);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFE), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xF7), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressB() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_B);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFE), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFB), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressA() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_A);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFE), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFD), keyboard.getLowByte());
+    }
+
+    @Test
+    public void testKeyboardKeyPressAT() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_AT);
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xFE), keyboard.getHighByte());
+        assertEquals(new UnsignedByte(0xFE), keyboard.getLowByte());
+    }
+}


### PR DESCRIPTION
This PR integrates the Keyboard component with the IO controller. Rather than writing keyboard presses directly into memory, the Keyboard will record the presses and releases, and the IO controller will read them when an IO memory address is read. Unit tests for all keyboard keys have been added.