### PR TITLE
Implement IRQ, and framework for FIRQ and NMI interrupt system

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Below are a list of items that are currently working:
 - SAM Display Offset Registers (`$FFC6` - `$FFD3`)
 - SAM TY Bits (`$FFDE`, `$FFDF`) 
 - Cassette tape interface
+- IRQ Interrupts (both PIA and GIME)
 
 Yet to be implemented:
 
@@ -169,6 +170,6 @@ Yet to be implemented:
 - Vertical Scroll Register (`$FF9C`)
 - Horizontal Offset Register (`$FF9F`)
 - Palette Registers (`$FFB0` - `$FFBF`) 
-- IRQ, FIRQ, and NMI interrupts
+- FIRQ and NMI interrupts
 - PIA2 interface
 - Sound

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
@@ -51,6 +51,7 @@ public class Emulator
         ioController = new IOController(memory, new RegisterSet(), keyboard, screen, cassette);
         cpu = new CPU(ioController);
         cpu.setTrace(trace);
+        ioController.setCPU(cpu);
 
         initEmulatorJFrame();
 
@@ -171,7 +172,6 @@ public class Emulator
         TimerTask task = new TimerTask() {
             public void run() {
                 screen.refreshScreen();
-                memory.writeByte(new UnsignedWord(0x0200), new UnsignedByte(0x1));
                 refreshScreen();
             }
         };

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Memory.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Memory.java
@@ -196,6 +196,7 @@ public class Memory
         /* RAM only */
         if (allRAMMode) {
             memory[getPhysicalAddress(par, intAddress)] = value.getShort();
+            return;
         }
 
         /* RAM + ROM modes - don't write anything to 3C, 3D, 3E, 3F*/

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedByte.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedByte.java
@@ -137,19 +137,6 @@ public class UnsignedByte
         this.value = value.getShort();
     }
 
-    /**
-     * Swaps the high nibble and the low nibble of the byte.
-     */
-    public void swapNibbles() {
-        int low = value & 0x0F;
-        int high = value & 0xF0;
-
-        low = low << 4;
-        high = high >> 4;
-
-        value = (short) (low + high);
-    }
-
     public String toString() {
         return String.format("%02X", value);
     }


### PR DESCRIPTION
This PR adds support for the two types of interrupt system implemented on the Color Computer 3. The first is the old PIA system of interrupts. This PR adds support for both IRQ and FIRQ interrupts on the PIA system, and implements timers for both the 63.5 microsecond and 16.6 millisecond timers. The second system of interrupts is the GIME based interrupts. This PR adds support for those IRQ and FIRQ interrupts, and adds timers for the HBORD, VBORD and custom timers. Unit tests added to match new functionality.