### PR TITLE
Disk Infrastructure and Interrupts Fix

### DIFF
--- a/src/main/java/ca/craigthomas/yacoco3e/common/IO.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/common/IO.java
@@ -32,7 +32,6 @@ public class IO
 
             /* Determine appropriate endianess */
             if (ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)) {
-                LOGGER.info("little endian system detected");
                 ByteArrayOutputStream tempStream = new ByteArrayOutputStream();
                 byte[] bytes = new byte[2];
                 int bytesRead = stream.read(bytes);
@@ -43,7 +42,6 @@ public class IO
                 data = tempStream.toByteArray();
                 tempStream.close();
             } else {
-                LOGGER.info("big endian system detected");
                 data = IOUtils.toByteArray(stream);
             }
             return data;

--- a/src/main/java/ca/craigthomas/yacoco3e/components/DiskDrive.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/DiskDrive.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 Craig Thomas
+ * This project uses an MIT style license - see LICENSE for details.
+ */
+package ca.craigthomas.yacoco3e.components;
+
+public class DiskDrive
+{
+    public static final int TRACKS = 35;
+    public static final int SECTORS = 18;
+    public static final int BYTES_PER_SECTOR = 256;
+
+    protected boolean motorOn;
+
+    protected int track;
+    protected int sector;
+    protected byte [] diskData;
+
+    protected IOController io;
+
+    public DiskDrive(IOController io) {
+        diskData = new byte [TRACKS * SECTORS * BYTES_PER_SECTOR];
+        motorOn = false;
+        this.io = io;
+    }
+
+    public int getTrack() {
+        return track;
+    }
+
+    public int getSector() {
+        return sector;
+    }
+}

--- a/src/main/java/ca/craigthomas/yacoco3e/components/DiskDrive.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/DiskDrive.java
@@ -15,8 +15,12 @@ public class DiskDrive
     protected boolean motorOn;
 
     protected int track;
+    protected int currentTrack;
     protected int sector;
+    protected int currentSector;
     protected byte [] diskData;
+    protected UnsignedByte dataRegister;
+    protected int direction;
 
     protected boolean haltEnabled;
 
@@ -26,6 +30,7 @@ public class DiskDrive
         diskData = new byte [TRACKS * SECTORS * BYTES_PER_SECTOR];
         motorOn = false;
         this.io = io;
+        direction = -1;
     }
 
     public int getTrack() {
@@ -58,5 +63,128 @@ public class DiskDrive
 
     public void disableHalt() {
         haltEnabled = false;
+    }
+
+    /**
+     * Executes the specified command on the disk.
+     *
+     * @param command the command to execute
+     */
+    public void executeCommand(UnsignedByte command) {
+        int intCommand = command.getShort() >> 4;
+        boolean verify = command.isMasked(0x04);
+
+        /* Restore - seek track 0 */
+        if (intCommand == 0x0) {
+            restore(verify);
+            return;
+        }
+
+        /* Seek - seek to track specified in track register */
+        if (intCommand == 0x1) {
+            seek(verify);
+            return;
+        }
+
+        /* Step without Update - steps once in the last direction */
+        if (intCommand == 0x2) {
+            step(false, verify);
+            return;
+        }
+
+        /* Step with Update - steps once in the last direction */
+        if (intCommand == 0x3) {
+            step(true, verify);
+            return;
+        }
+
+        /* Step In without Update - steps once towards track 76 */
+        if (intCommand == 0x4) {
+            stepIn(false, verify);
+            return;
+        }
+
+        /* Step In with Update - steps once towards track 76 */
+        if (intCommand == 0x5) {
+            stepIn(true, verify);
+            return;
+        }
+
+        /* Step Out without Update - steps once towards track 0 */
+        if (intCommand == 0x6) {
+            stepOut(false, verify);
+            return;
+        }
+
+        /* Step In with Update - steps once towards track 0 */
+        if (intCommand == 0x7) {
+            stepOut(true, verify);
+            return;
+        }
+    }
+
+    /**
+     * Seeks to track 0.
+     */
+    public void restore(boolean verify) {
+        currentTrack = 0;
+        direction = -1;
+        setTrack(new UnsignedByte(0));
+        io.nonMaskableInterrupt();
+    }
+
+    /**
+     * Seeks to the track specified in the data register.
+     */
+    public void seek(boolean verify) {
+        int trackToSeek = dataRegister.getShort();
+        while (currentTrack > trackToSeek) {
+            direction = -1;
+            currentTrack--;
+        }
+
+        while (currentTrack < trackToSeek) {
+            direction = 1;
+            currentTrack++;
+        }
+
+        setTrack(dataRegister);
+        io.nonMaskableInterrupt();
+    }
+
+    /**
+     * Steps once in the last direction.
+     *
+     * @param update if true, update the track status register
+     * @param verify if true, verifies the last operation succeeded
+     */
+    public void step(boolean update, boolean verify) {
+        currentTrack += direction;
+        if (update) {
+            setTrack(new UnsignedByte(currentTrack));
+        }
+        io.nonMaskableInterrupt();
+    }
+
+    /**
+     * Steps once towards track 76.
+     *
+     * @param update if true, update the track status register
+     * @param verify if true, verifies the last operation succeeded
+     */
+    public void stepIn(boolean update, boolean verify) {
+        direction = 1;
+        step(update, verify);
+    }
+
+    /**
+     * Steps once towards track 0.
+     *
+     * @param update if true, update the track status register
+     * @param verify if true, verifies the last operation succeeded
+     */
+    public void stepOut(boolean update, boolean verify) {
+        direction = -1;
+        step(update, verify);
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/DiskDrive.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/DiskDrive.java
@@ -4,6 +4,8 @@
  */
 package ca.craigthomas.yacoco3e.components;
 
+import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
+
 public class DiskDrive
 {
     public static final int TRACKS = 35;
@@ -15,6 +17,8 @@ public class DiskDrive
     protected int track;
     protected int sector;
     protected byte [] diskData;
+
+    protected boolean haltEnabled;
 
     protected IOController io;
 
@@ -28,7 +32,31 @@ public class DiskDrive
         return track;
     }
 
+    public void setTrack(UnsignedByte track) {
+        this.track = track.getShort();
+    }
+
     public int getSector() {
         return sector;
+    }
+
+    public void setSector(UnsignedByte sector) {
+        this.sector = sector.getShort();
+    }
+
+    public void turnMotorOn() {
+        motorOn = true;
+    }
+
+    public void turnMotorOff() {
+        motorOn = false;
+    }
+
+    public void enableHalt() {
+        haltEnabled = true;
+    }
+
+    public void disableHalt() {
+        haltEnabled = false;
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
@@ -43,7 +43,7 @@ public class Emulator
     /* A logger for the emulator */
     private final static Logger LOGGER = Logger.getLogger(Emulator.class.getName());
 
-    public Emulator(int scaleFactor, String romFile, boolean trace, String cassetteFile) {
+    public Emulator(int scaleFactor, String romFile, boolean trace, String cassetteFile, String diskBasicROM) {
         memory = new Memory();
         keyboard = new Keyboard();
         screen = new Screen(scaleFactor);
@@ -65,6 +65,19 @@ public class Emulator
         } else {
             LOGGER.severe("no ROM file specified");
             System.exit(1);
+        }
+
+        // Check to see if disk basic was specified
+        if (diskBasicROM != null) {
+            InputStream romFileStream = IO.openInputStream(diskBasicROM);
+            if (!memory.loadCartROM(IO.loadStream(romFileStream))) {
+                LOGGER.severe("Could not load Disk Basic ROM file [" + diskBasicROM + "]");
+            } else {
+                LOGGER.info("Loaded Disk Basic ROM [" + diskBasicROM + "]");
+            }
+            IO.closeStream(romFileStream);
+        } else {
+            LOGGER.info("Disk Basic ROM file not specified");
         }
 
         // Attempt to load specified cassette file

--- a/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
@@ -153,6 +153,7 @@ public class IOController
         /* Disks */
         diskDriveSelect = 0;
 
+        /* Initialize drive data */
         disk = new DiskDrive[NUM_DISK_DRIVES];
         for (int i = 0; i < NUM_DISK_DRIVES; i++) {
             disk[i] = new DiskDrive(this);
@@ -413,6 +414,11 @@ public class IOController
                 } else {
                     disk[diskDriveSelect].disableHalt();
                 }
+                break;
+
+            /* Disk Command Register */
+            case 0xFF48:
+                disk[diskDriveSelect].executeCommand(value);
                 break;
 
             /* Track Status Register */
@@ -1446,5 +1452,12 @@ public class IOController
                 cpu.fastInterruptRequest();
             }
         }
+    }
+
+    /**
+     * Fires a non-maskable interrupt on the CPU.
+     */
+    public void nonMaskableInterrupt() {
+        cpu.nonMaskableInterruptRequest();
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
@@ -21,6 +21,12 @@ public class IOController
     protected Screen screen;
     protected Cassette cassette;
     protected CPU cpu;
+    protected DiskDrive [] disk;
+
+    /* Disk Drive Selector */
+    protected int diskDriveSelect;
+
+    /* Disk Drives Present */
 
     /* CoCo Compatible Mode */
     protected boolean cocoCompatibleMode;
@@ -361,6 +367,11 @@ public class IOController
                 /* Bit 1 = hi/lo edge triggered */
 
                 pia2CRB = value.copy();
+                break;
+
+
+            /* Disk Drive Control Register */
+            case 0xFF40:
                 break;
 
             /* INIT 0 */

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Memory.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Memory.java
@@ -183,6 +183,22 @@ public class Memory
     }
 
     /**
+     * This routine is used to map the upper 16 bytes from either
+     * ROM or CART ROM to the addresses $FFF0 - $FFFF.
+     *
+     * @param address the address to read from
+     * @return the ROM byte at that location
+     */
+    public UnsignedByte readROMByte(int address) {
+        /* CART ROM = 32K ROM - read from lower 16K */
+        if (romMode.equals(new UnsignedByte(0x3))) {
+            return new UnsignedByte(cartROM[0x3FF0 + (address & 0x000F)]);
+        }
+
+        return new UnsignedByte(rom[0x3FF0 + (address & 0x000F)]);
+    }
+
+    /**
      * Writes an UnsignedByte to the specified memory address. If the system
      * is in a ROM mode, will not write bytes to a ROM location.
      *

--- a/src/main/java/ca/craigthomas/yacoco3e/runner/Arguments.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/runner/Arguments.java
@@ -22,4 +22,7 @@ public class Arguments
 
     @Parameter(names="--cassette", description="cassette file")
     public String cassetteFile;
+
+    @Parameter(names="--diskbas", description="Disk Basic ROM")
+    public String diskBasicROM;
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/runner/Runner.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/runner/Runner.java
@@ -24,7 +24,8 @@ public class Runner
         jCommander.parse(argv);
 
         /* Create the emulator and start it running */
-        Emulator emulator = new Emulator(arguments.scale, arguments.romFile, arguments.trace, arguments.cassetteFile);
+        Emulator emulator = new Emulator(arguments.scale, arguments.romFile, arguments.trace, arguments.cassetteFile,
+                arguments.diskBasicROM);
         emulator.start();
     }
 }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
@@ -251,8 +251,6 @@ public class IOControllerTest
         io.getCC().and(~IOController.CC_I);
         io.timerTick(1);
         assertEquals(0, io.pia1SlowTimer);
-        assertFalse(io.pia1CRA.isMasked(0x80));
-        assertFalse(io.pia1CRB.isMasked(0x80));
     }
 
     @Test
@@ -283,8 +281,11 @@ public class IOControllerTest
     @Test
     public void testGIMETimerInterruptFiresCorrectly() {
         memory.enableAllRAMMode();
+        memory.rom = new short [0x4000];
+        memory.rom[0x3FF8] = (short) 0xDE;
+        memory.rom[0x3FF9] = (short) 0xAD;
+
         regs.setS(new UnsignedWord(0x0300));
-        io.writeWord(new UnsignedWord(0xFFF8), new UnsignedWord(0xDEAD));
         io.timerTickCounter = 999999;
         io.timerResetValue = new UnsignedWord(0xBEEF);
         io.timerValue = new UnsignedWord(0x1);
@@ -298,8 +299,11 @@ public class IOControllerTest
     @Test
     public void testGIMETimerFastInterruptFiresCorrectly() {
         memory.enableAllRAMMode();
+        memory.rom = new short [0x4000];
+        memory.rom[0x3FF6] = (short) 0xDE;
+        memory.rom[0x3FF7] = (short) 0xAD;
+
         regs.setS(new UnsignedWord(0x0300));
-        io.writeWord(new UnsignedWord(0xFFF6), new UnsignedWord(0xDEAD));
         io.timerTickCounter = 999999;
         io.timerResetValue = new UnsignedWord(0xBEEF);
         io.timerValue = new UnsignedWord(0x1);
@@ -313,8 +317,11 @@ public class IOControllerTest
     @Test
     public void testGIMEHorizontalBorderInterruptFiresCorrectly() {
         memory.enableAllRAMMode();
+        memory.rom = new short [0x4000];
+        memory.rom[0x3FF8] = (short) 0xDE;
+        memory.rom[0x3FF9] = (short) 0xAD;
+
         regs.setS(new UnsignedWord(0x0300));
-        io.writeWord(new UnsignedWord(0xFFF8), new UnsignedWord(0xDEAD));
         io.horizontalBorderTickValue = 999999;
         io.irqEnabled = true;
         io.irqStatus = new UnsignedByte(0x10);
@@ -325,8 +332,11 @@ public class IOControllerTest
     @Test
     public void testGIMEHorizontalBorderFastInterruptFiresCorrectly() {
         memory.enableAllRAMMode();
+        memory.rom = new short [0x4000];
+        memory.rom[0x3FF6] = (short) 0xDE;
+        memory.rom[0x3FF7] = (short) 0xAD;
+
         regs.setS(new UnsignedWord(0x0300));
-        io.writeWord(new UnsignedWord(0xFFF6), new UnsignedWord(0xDEAD));
         io.horizontalBorderTickValue = 999999;
         io.firqEnabled = true;
         io.firqStatus = new UnsignedByte(0x10);
@@ -337,8 +347,11 @@ public class IOControllerTest
     @Test
     public void testGIMEVerticalBorderInterruptFiresCorrectly() {
         memory.enableAllRAMMode();
+        memory.rom = new short [0x4000];
+        memory.rom[0x3FF8] = (short) 0xDE;
+        memory.rom[0x3FF9] = (short) 0xAD;
+
         regs.setS(new UnsignedWord(0x0300));
-        io.writeWord(new UnsignedWord(0xFFF8), new UnsignedWord(0xDEAD));
         io.verticalBorderTickValue = 999999;
         io.irqEnabled = true;
         io.irqStatus = new UnsignedByte(0x8);
@@ -349,8 +362,11 @@ public class IOControllerTest
     @Test
     public void testGIMEVerticalBorderFastInterruptFiresCorrectly() {
         memory.enableAllRAMMode();
+        memory.rom = new short [0x4000];
+        memory.rom[0x3FF6] = (short) 0xDE;
+        memory.rom[0x3FF7] = (short) 0xAD;
+
         regs.setS(new UnsignedWord(0x0300));
-        io.writeWord(new UnsignedWord(0xFFF6), new UnsignedWord(0xDEAD));
         io.verticalBorderTickValue = 999999;
         io.firqEnabled = true;
         io.firqStatus = new UnsignedByte(0x8);
@@ -850,7 +866,10 @@ public class IOControllerTest
 
     @Test
     public void testGetIndexedPCWith8BitNegativeOffsetIndexed() throws IllegalIndexedPostbyteException{
-        io.writeWord(new UnsignedWord(0xFFFC), new UnsignedWord(0xBEEF));
+        memory.rom = new short [0x4000];
+        memory.rom[0x3FFC] = (short) 0xBE;
+        memory.rom[0x3FFD] = (short) 0xEF;
+
         io.writeWord(new UnsignedWord(0x0000), new UnsignedWord(0x9CFA));
         assertEquals(new UnsignedWord(0xBEEF), io.getIndexed().get());
     }
@@ -936,6 +955,9 @@ public class IOControllerTest
 
     @Test
     public void testResetSetsCorrectValues() {
+        memory.rom = new short [0x4000];
+        memory.rom[0x3FFE] = (short) 0xC0;
+
         io.reset();
         assertFalse(io.ccOverflowSet());
         assertFalse(io.ccNegativeSet());


### PR DESCRIPTION
This PR introduces the disk drive system. It also includes a fix for the interrupt system. Interrupts are now inhibited when the condition code register is set high. It also introduces a new memory routine for reading addresses $FFF0 - $FFFF (These addresses should be read from the ROM regardless of the memory mapping mode and the MMU). 