### PR TITLE
Implement small fix for disk systems

### DIFF
--- a/src/main/java/ca/craigthomas/yacoco3e/components/DiskSector.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/DiskSector.java
@@ -127,7 +127,8 @@ public class DiskSector
 
             case LOAD_VIRTUAL_DISK:
                 id.restore();
-                data.restore();
+                data.restorePastGap();
+                pointer = 0;
                 break;
         }
 

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/JV1Disk.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/JV1Disk.java
@@ -87,10 +87,7 @@ public class JV1Disk implements VirtualDisk
                 tracks[trackNum].writeSectorId(sectorNum, new UnsignedByte(0x00));
 
                 // Write out sector data
-                tracks[trackNum].writeData(sectorNum, new UnsignedByte(0xA1));
-                tracks[trackNum].writeData(sectorNum, new UnsignedByte(0xA1));
-                tracks[trackNum].writeData(sectorNum, new UnsignedByte(0xA1));
-                tracks[trackNum].writeData(sectorNum, new UnsignedByte(0xFB));
+                tracks[trackNum].writeDataMark(sectorNum, new UnsignedByte(0xFB));
 
                 // Write out raw data
                 for (int j = 0; j < 256; j++) {


### PR DESCRIPTION
This PR implements a fix for the disk drive system. Bytes for certain sectors were not being loaded correctly into the DiskTrack class. 