### PR TITLE
Bugfix: Do Not Write To Cassette When Not In Record

### DIFF
--- a/src/main/java/ca/craigthomas/yacoco3e/components/Cassette.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Cassette.java
@@ -185,6 +185,11 @@ public class Cassette
      * @param newByte the byte to interpret
      */
     public void byteInput(UnsignedByte newByte) {
+        /* Make sure we are set to record */
+        if (mode != Mode.RECORD) {
+            return;
+        }
+
         float voltage = 0.0f;
 
         /* Interpret the voltage based on bit value set */

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CassetteTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CassetteTest.java
@@ -244,6 +244,7 @@ public class CassetteTest
     public void testByteInputRecordsCorrectByte() {
         cassette.inputBuffer = new byte[2];
         cassette.rewind();
+        cassette.record();
         cassette.motorOn();
 
         /* Record the pattern F0 */
@@ -367,6 +368,7 @@ public class CassetteTest
     public void testByteInputShortPulsesIgnored() {
         cassette.inputBuffer = new byte[2];
         cassette.rewind();
+        cassette.record();
         cassette.motorOn();
 
         /* Record the pattern F0 */


### PR DESCRIPTION
This PR solves a bug where a null pointer exception occurred when a write to the cassette buffer occurred before the cassette buffer was set up. The fix is to ensure that the cassette is in RECORD mode before trying to write to the cassette buffer.