### PR TITLE
Cassette fix

### DIFF
--- a/src/main/java/ca/craigthomas/yacoco3e/components/Cassette.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Cassette.java
@@ -280,12 +280,14 @@ public class Cassette
     /**
      * Checks to make sure that the buffer contains a proper EOF block.
      * If it does not, will correct it to ensure that it does.
+     *
+     * @return true if proper EOF found or EOF corrected, false otherwise
      */
-    public void checkForEOF() {
+    public boolean checkForEOF() {
         int length = cassetteBytes.length;
 
         if (cassetteBytes[length - 1] == 0x55 && cassetteBytes[length - 6] == 0x55) {
-            return;
+            return true;
         }
 
         LOGGER.warning("cassette data contains malformed EOF block - correcting");
@@ -302,7 +304,7 @@ public class Cassette
         // Check to see if there is another 0x55 before it
         if (cassetteBytes[lastIndexOf55 - 1] != 0x55) {
             LOGGER.severe("unable to correct tape pattern, please check data manually");
-            return;
+            return false;
         }
 
         // Create a new array for the cassette bytes and copy old to new
@@ -320,5 +322,6 @@ public class Cassette
         newCassetteBytes[truncatedLength + 4] = (byte) 0xFF;
         newCassetteBytes[truncatedLength + 5] = 0x55;
         cassetteBytes = newCassetteBytes;
+        return true;
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Cassette.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Cassette.java
@@ -8,6 +8,8 @@ import ca.craigthomas.yacoco3e.common.IO;
 import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
 
 import java.io.*;
+import java.util.Arrays;
+import java.util.logging.Logger;
 
 import static ca.craigthomas.yacoco3e.common.IO.flushToStream;
 import static ca.craigthomas.yacoco3e.common.IO.openInputStream;
@@ -60,6 +62,9 @@ public class Cassette
 
     /* The last input bit we saw */
     private byte lastInputBit;
+
+    /* A logger for the cassette drive */
+    private final static Logger LOGGER = Logger.getLogger(Cassette.class.getName());
 
     public Cassette() {
         mode = Mode.PLAY;
@@ -250,6 +255,8 @@ public class Cassette
         IO.closeStream(stream);
         rewind();
 
+        checkForEOF();
+
         return true;
     }
 
@@ -268,5 +275,50 @@ public class Cassette
      */
     public Mode getMode() {
         return mode;
+    }
+
+    /**
+     * Checks to make sure that the buffer contains a proper EOF block.
+     * If it does not, will correct it to ensure that it does.
+     */
+    public void checkForEOF() {
+        int length = cassetteBytes.length;
+
+        if (cassetteBytes[length - 1] == 0x55 && cassetteBytes[length - 6] == 0x55) {
+            return;
+        }
+
+        LOGGER.warning("cassette data contains malformed EOF block - correcting");
+
+        // Backup until we hit the last 0x55 characters
+        int lastIndexOf55 = 0;
+        for (int ptr = length -1; ptr > 0; ptr--) {
+            if (cassetteBytes[ptr] == 0x55) {
+                lastIndexOf55 = ptr;
+                break;
+            }
+        }
+
+        // Check to see if there is another 0x55 before it
+        if (cassetteBytes[lastIndexOf55 - 1] != 0x55) {
+            LOGGER.severe("unable to correct tape pattern, please check data manually");
+            return;
+        }
+
+        // Create a new array for the cassette bytes and copy old to new
+        int truncatedLength = length - (length - lastIndexOf55);
+        byte [] newCassetteBytes = new byte[truncatedLength + 6];
+        for (int ptr = 0; ptr < lastIndexOf55; ptr++) {
+            newCassetteBytes[ptr] = cassetteBytes[ptr];
+        }
+
+        // Add the trailing information for EOF
+        newCassetteBytes[truncatedLength] = 0x55;
+        newCassetteBytes[truncatedLength + 1] = 0x3C;
+        newCassetteBytes[truncatedLength + 2] = (byte) 0xFF;
+        newCassetteBytes[truncatedLength + 3] = 0x00;
+        newCassetteBytes[truncatedLength + 4] = (byte) 0xFF;
+        newCassetteBytes[truncatedLength + 5] = 0x55;
+        cassetteBytes = newCassetteBytes;
     }
 }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CassetteTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CassetteTest.java
@@ -9,9 +9,7 @@ import ca.craigthomas.yacoco3e.datatypes.UnsignedWord;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class CassetteTest
 {
@@ -509,5 +507,30 @@ public class CassetteTest
     @Test
     public void testOpenFileReturnsFalseWhenNullFile() {
         assertFalse(cassette.openFile("this-file-should-not-exist.cas"));
+    }
+
+    @Test
+    public void testCheckForEOFDoesNothingOnCorrectEOFBlock() {
+        byte [] goodBytes = {0x55, 0x55, 0x3C, (byte) 0xFF, 0x00, (byte) 0xFF, 0x55};
+        cassette.cassetteBytes = goodBytes;
+        assertTrue(cassette.checkForEOF());
+        assertArrayEquals(goodBytes, cassette.cassetteBytes);
+    }
+
+    @Test
+    public void testCheckForEOFCannotCorrectBadByteSequence() {
+        byte [] badBytes = {0x00, 0x55, 0x3C, (byte) 0xFF, 0x00, (byte) 0xFF};
+        cassette.cassetteBytes = badBytes;
+        assertFalse(cassette.checkForEOF());
+        assertArrayEquals(badBytes, cassette.cassetteBytes);
+    }
+
+    @Test
+    public void testCheckForEOFCorrectsBadByteSequence() {
+        byte [] badBytes = {0x55, 0x55, 0x3C, (byte) 0xFF, 0x00, (byte) 0xFF};
+        byte [] goodBytes = {0x55, 0x55, 0x3C, (byte) 0xFF, 0x00, (byte) 0xFF, 0x55};
+        cassette.cassetteBytes = badBytes;
+        assertTrue(cassette.checkForEOF());
+        assertArrayEquals(goodBytes, cassette.cassetteBytes);
     }
 }


### PR DESCRIPTION
This PR fixes an issue with cassette images not having the proper EOF block at the end of the data array. All cassette tape images must have the EOF block of bytes:

    `55, 3C, FF, 00, FF, 55`

A new function called `checkForEOF` was added to check for the proper byte pattern. The function will attempt to fix the EOF pattern so that the cassette tape will load. Unit tests added to match new functionality.