### PR TITLE
Update keyboard mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,29 +166,12 @@ file, and can be loaded from the host computer in a future session.
 
 ## Keyboard
 
-The Color Computer 3 keyboard maps most keys to their traditional 
-counterparts. However, there are some differences with shifted keys
-as well as some regular keystrokes. These are listed below:
+The emulated keyboard maps most keys to their traditional
+counterparts. Differences are listed below:
 
 | CoCo 3 Key | Keyboard Combination |
 | :--------: | :------------------: |
-| `!`        | `SHIFT`-`1`          |
-| `"`        | `SHIFT`-`2`          |
-| `#`        | `SHIFT`-`3`          |
-| `$`        | `SHIFT`-`4`          |
-| `%`        | `SHIFT`-`5`          |
-| `&`        | `SHIFT`-`6`          |
-| `'`        | `SHIFT`-`7`          |
-| `(`        | `SHIFT`-`8`          |
-| `)`        | `SHIFT`-`9`          |
-| `=`        | `SHIFT`-`-`          |
-| `+`        | `SHIFT`-`:`          |
-| `:`        | `'`                  |
-| `*`        | `SHIFT`-`'`          |
-| `@`        | `ALT`                |
 | `BREAK`    | `ESCAPE`             |
-
-Note that these key mappings are likely to change in the future.
 
 
 ## Current Status

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Keyboard.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Keyboard.java
@@ -31,9 +31,9 @@ import java.awt.event.KeyEvent;
  * HIGH
  *   7
  *   6   SHIFT   F2    F1   CTRL   ALT   BRK   CLR   ENTER
- *   5     /     .     -     ,      ;     "     9      8
+ *   5     /     .     -     ,      ;     :     9      8
  *   4     7     6     5     4      3     2     1      0
- *   3   SPACE   RIGHT LEFT  DOW    UP    z     y      x
+ *   3   SPACE   RIGHT LEFT  DOWN   UP    z     y      x
  *   2     w     v     u     t      s     r     q      p
  *   1     o     n     m     l      k     j     i      h
  *   0     g     f     e     d      c     b     a      @
@@ -42,7 +42,9 @@ import java.awt.event.KeyEvent;
  *                          LOW
  *
  *  The keypresses on the CoCo are recorded as active low values, therefore
- *  the byte values are inversed.
+ *  the byte values are inversed. The keyboard is read by strobing the low
+ *  byte values one at a time, and then reading the high byte value to see
+ *  if it is active.
  */
 public class Keyboard extends KeyAdapter
 {
@@ -70,8 +72,92 @@ public class Keyboard extends KeyAdapter
     @Override
     public void keyPressed(KeyEvent e) {
         int keyPressed = e.getKeyCode();
-        switch (keyPressed) {
 
+        if (e.getKeyChar() == '!') {
+            column7.or(0x40);
+            column1.or(0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '#') {
+            column7.or(0x40);
+            column3.or(0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '$') {
+            column7.or(0x40);
+            column4.or(0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '%') {
+            column7.or(0x40);
+            column5.or(0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == ':') {
+            column2.or(0x20);
+            column7.and(~0x40);
+            return;
+        }
+
+        if (e.getKeyChar() == '\'') {
+            column7.or(0x40);
+            column7.or(0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '=') {
+            column7.or(0x40);
+            column5.or(0x20);
+            return;
+        }
+
+        if (e.getKeyChar() == '@') {
+            column0.or(0x01);
+            column7.and(~0x40);
+            return;
+        }
+
+        if (e.getKeyChar() == '"') {
+            column7.or(0x40);
+            column2.or(0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '*') {
+            column7.or(0x40);
+            column2.or(0x20);
+            return;
+        }
+
+        if (e.getKeyChar() == '&') {
+            column7.or(0x40);
+            column6.or(0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '(') {
+            column7.or(0x40);
+            column0.or(0x20);
+            return;
+        }
+
+        if (e.getKeyChar() == ')') {
+            column7.or(0x40);
+            column1.or(0x20);
+            return;
+        }
+
+        if (e.getKeyChar() == '+') {
+            column7.or(0x40);
+            column3.or(0x20);
+            return;
+        }
+
+        switch (keyPressed) {
             /* SHIFT */
             case KeyEvent.VK_SHIFT:
                 column7.or(0x40);
@@ -137,7 +223,7 @@ public class Keyboard extends KeyAdapter
                 column3.or(0x20);
                 break;
 
-            /* ' */
+            /* : */
             case KeyEvent.VK_QUOTE:
                 column2.or(0x20);
                 break;
@@ -204,6 +290,7 @@ public class Keyboard extends KeyAdapter
 
             /* LEFT ARROW */
             case KeyEvent.VK_LEFT:
+            case KeyEvent.VK_BACK_SPACE:
                 column5.or(0x08);
                 break;
 
@@ -347,11 +434,6 @@ public class Keyboard extends KeyAdapter
                 column1.or(0x01);
                 break;
 
-            /* @ */
-            case KeyEvent.VK_AT:
-                column0.or(0x01);
-                break;
-
             default:
                 break;
         }
@@ -360,6 +442,91 @@ public class Keyboard extends KeyAdapter
     @Override
     public void keyReleased(KeyEvent e) {
         int keyPressed = e.getKeyCode();
+
+        if (e.getKeyChar() == '!') {
+            column7.and(~0x40);
+            column1.and(~0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '#') {
+            column7.and(~0x40);
+            column3.and(~0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '$') {
+            column7.and(~0x40);
+            column4.and(~0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '%') {
+            column7.and(~0x40);
+            column5.and(~0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == ':') {
+            column2.and(~0x20);
+            column7.and(~0x40);
+            return;
+        }
+
+        if (e.getKeyChar() == '\'') {
+            column7.and(~0x40);
+            column7.and(~0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '=') {
+            column7.and(~0x40);
+            column5.and(~0x20);
+            return;
+        }
+
+        if (e.getKeyChar() == '@') {
+            column0.and(~0x01);
+            column7.and(~0x40);
+            return;
+        }
+
+        if (e.getKeyChar() == '"') {
+            column7.and(~0x40);
+            column2.and(~0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '*') {
+            column7.and(~0x40);
+            column2.and(~0x20);
+            return;
+        }
+
+        if (e.getKeyChar() == '&') {
+            column7.and(~0x40);
+            column6.and(~0x10);
+            return;
+        }
+
+        if (e.getKeyChar() == '(') {
+            column7.and(~0x40);
+            column0.and(~0x20);
+            return;
+        }
+
+        if (e.getKeyChar() == ')') {
+            column7.and(~0x40);
+            column1.and(~0x20);
+            return;
+        }
+
+        if (e.getKeyChar() == '+') {
+            column7.and(~0x40);
+            column3.and(~0x20);
+            return;
+        }
+
         switch (keyPressed) {
 
             /* SHIFT */
@@ -427,7 +594,7 @@ public class Keyboard extends KeyAdapter
                 column3.and(~0x20);
                 break;
 
-            /* ' */
+            /* : */
             case KeyEvent.VK_QUOTE:
                 column2.and(~0x20);
                 break;
@@ -494,6 +661,7 @@ public class Keyboard extends KeyAdapter
 
             /* LEFT ARROW */
             case KeyEvent.VK_LEFT:
+            case KeyEvent.VK_BACK_SPACE:
                 column5.and(~0x08);
                 break;
 
@@ -635,11 +803,6 @@ public class Keyboard extends KeyAdapter
             /* A */
             case KeyEvent.VK_A:
                 column1.and(~0x01);
-                break;
-
-            /* @ */
-            case KeyEvent.VK_AT:
-                column0.and(~0x01);
                 break;
 
             default:

--- a/src/test/java/ca/craigthomas/yacoco3e/components/KeyboardTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/KeyboardTest.java
@@ -355,9 +355,9 @@ public class KeyboardTest
 
     @Test
     public void testKeyboardKeyPressH() {
-        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_P);
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_H);
         keyboard.keyPressed(event);
-        assertEquals(new UnsignedByte(0xFB), keyboard.getHighByte(new UnsignedByte(0xFE)));
+        assertEquals(new UnsignedByte(0xFD), keyboard.getHighByte(new UnsignedByte(0xFE)));
     }
 
     @Test
@@ -410,9 +410,674 @@ public class KeyboardTest
     }
 
     @Test
-    public void testKeyboardKeyPressAT() {
-        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_AT);
+    public void testKeyboardKeyReleasedShift() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_SHIFT);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedF2() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_F2);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xBF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedF1() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_F1);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedCTRL() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_CONTROL);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xEF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedALT() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_ALT);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedESC() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_ESCAPE);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedHOME() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_HOME);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedENTER() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_ENTER);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedSlash() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_SLASH);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedPeriod() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_PERIOD);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xBF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedMinus() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_MINUS);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedComma() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_COMMA);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xEF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedSemicolon() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_SEMICOLON);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedQuote() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_QUOTE);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased9() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_9);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased8() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_8);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased7() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_7);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased6() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_6);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xBF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased5() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_5);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased4() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_4);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xEF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased3() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_3);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased2() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_2);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased1() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_1);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleased0() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_0);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedSpace() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_SPACE);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedRight() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_RIGHT);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xBF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedLeft() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_LEFT);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedDown() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_DOWN);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xEF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedUp() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_UP);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedZ() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_Z);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedY() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_Y);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedX() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_X);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedW() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_W);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedV() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_V);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xBF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedU() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_U);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedT() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_T);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xEF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedS() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_S);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedR() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_R);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedQ() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_Q);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedP() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_P);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedO() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_O);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedN() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_N);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xBF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedM() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_M);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedL() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_L);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xEF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedK() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_K);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedJ() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_J);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedI() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_I);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedH() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_H);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedG() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_G);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedF() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_F);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xBF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedE() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_E);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedD() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_D);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xEF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedC() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_C);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedB() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_B);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedA() {
+        Mockito.when(event.getKeyCode()).thenReturn(KeyEvent.VK_A);
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressColon() {
+        Mockito.when(event.getKeyChar()).thenReturn(':');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedColon() {
+        Mockito.when(event.getKeyChar()).thenReturn(':');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressExclaim() {
+        Mockito.when(event.getKeyChar()).thenReturn('!');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedExclaim() {
+        Mockito.when(event.getKeyChar()).thenReturn('!');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressAt() {
+        Mockito.when(event.getKeyChar()).thenReturn('@');
         keyboard.keyPressed(event);
         assertEquals(new UnsignedByte(0xFE), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedAt() {
+        Mockito.when(event.getKeyChar()).thenReturn('@');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressPound() {
+        Mockito.when(event.getKeyChar()).thenReturn('#');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedPound() {
+        Mockito.when(event.getKeyChar()).thenReturn('#');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressDollar() {
+        Mockito.when(event.getKeyChar()).thenReturn('$');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte(new UnsignedByte(0xEF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedDollar() {
+        Mockito.when(event.getKeyChar()).thenReturn('$');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xEF)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressPercent() {
+        Mockito.when(event.getKeyChar()).thenReturn('%');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedPercent() {
+        Mockito.when(event.getKeyChar()).thenReturn('%');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressAmpersand() {
+        Mockito.when(event.getKeyChar()).thenReturn('&');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte(new UnsignedByte(0xBF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedAmpersand() {
+        Mockito.when(event.getKeyChar()).thenReturn('&');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xBF)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressLeftBracket() {
+        Mockito.when(event.getKeyChar()).thenReturn('(');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedLeftBracket() {
+        Mockito.when(event.getKeyChar()).thenReturn('(');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFE)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressRightBracket() {
+        Mockito.when(event.getKeyChar()).thenReturn(')');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedRightBracket() {
+        Mockito.when(event.getKeyChar()).thenReturn(')');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFD)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressAsterisk() {
+        Mockito.when(event.getKeyChar()).thenReturn('*');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedAsterisk() {
+        Mockito.when(event.getKeyChar()).thenReturn('*');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressPlus() {
+        Mockito.when(event.getKeyChar()).thenReturn('+');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedPlus() {
+        Mockito.when(event.getKeyChar()).thenReturn('+');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xF7)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressEquals() {
+        Mockito.when(event.getKeyChar()).thenReturn('=');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xDF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedEquals() {
+        Mockito.when(event.getKeyChar()).thenReturn('=');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xDF)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressDoubleQuote() {
+        Mockito.when(event.getKeyChar()).thenReturn('"');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xBF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xEF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedDoubleQuote() {
+        Mockito.when(event.getKeyChar()).thenReturn('"');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0xFB)));
+    }
+
+    @Test
+    public void testKeyboardKeyPressSingleQuote() {
+        Mockito.when(event.getKeyChar()).thenReturn('\'');
+        keyboard.keyPressed(event);
+        assertEquals(new UnsignedByte(0xAF), keyboard.getHighByte(new UnsignedByte(0x7F)));
+    }
+
+    @Test
+    public void testKeyboardKeyReleasedSingleQuote() {
+        Mockito.when(event.getKeyChar()).thenReturn('\'');
+        keyboard.keyPressed(event);
+        keyboard.keyReleased(event);
+        assertEquals(new UnsignedByte(0xFF), keyboard.getHighByte(new UnsignedByte(0x7F)));
     }
 }


### PR DESCRIPTION
This PR updates the keyboard key scan routines to allow for a more natural mapping between the PC keyboard and the CoCo keyboard. In particular, exceptions were added to allow characters such as `(` to be mapped to `SHIFT`-`9` instead of `SHIFT`-`8` like on the CoCo keyboard. Following this PR, all keyboard key mappings on the physical machine will translate properly to the CoCo keys. Unit tests updated to cover all new functionality, as well as updated to test all key releases as well.