### PR TITLE
Implement Configuration Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 2. [License](#license)
 3. [Compiling](#compiling)
 4. [Running](#running)
-    1. [Running a ROM](#running-a-rom)
+    1. [Specifying a System ROM](#specifying-a-system-rom)
     2. [Trace Mode](#trace-mode)
 5. [Cassette Tapes](#cassette-tapes)
     1. [Reading](#reading)
@@ -20,8 +20,9 @@
 6. [Disk Drives](#disk-drives)
     1. [Loading a Disk Image](#loading-a-disk-image)
     2. [Saving a Disk Image](#saving-a-disk-image)
-7. [Keyboard](#keyboard)
-8. [Current Status](#current-status)
+7. [Configuration File](#configuration-file)
+8. [Keyboard](#keyboard)
+9. [Current Status](#current-status)
 
 ## What Is It?
 
@@ -75,16 +76,34 @@ The compiled Jar file will be placed in the `build/libs` directory.
 
 ## Running
 
-#### Running a ROM
+For the emulator to run, you will need to have the Java 8 Runtime Environment (JRE)
+installed on your computer. See [Oracle's Java SE Runtime Environment Download](https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html)
+page for more information on installing the JRE. Alternatively, you can
+use [OpenJDK](https://openjdk.java.net/install/).
 
-The command-line interface requires a single argument, which is the
-path to a Color Computer 3 ROM file. The ROM may be either a 
-Super-Extended Color Basic ROM, or a cartridge ROM. The syntax is as
-follows:
+Simply double-clicking the jar file will start the emulator running. By
+default, the emulator will be in paused mode until you attach a system
+ROM to it. You can do so by clicking *ROM*, *Load System ROM*. You can
+also specify what ROM file to load via the command line (see [Specifying
+a System ROM](#specifying-a-system-rom) section below on how to specify a ROM on the
+command-line, and the [Configuration File](#configuration-file) section
+below on how to create a configuration file so you don't have to specify
+the system ROM each time you start the emulator).
+
+
+#### Specifying a System ROM
+
+The system ROM refers to the basic operating system of the machine.
+Usually this is a Super Extended Color Basic ROM, or a cartridge ROM.
+The syntax to specify the system ROM is as follows:
 
 ```bash
-java -jar build/libs/yacoco3e-1.0-all.jar /path/to/rom/file.rom
+java -jar build/libs/yacoco3e-1.0-all.jar --system /path/to/rom/file.rom
 ```
+
+See the section on [Configuration File](#configuration-file) for more
+information on how to create a configuration file so that you don't
+have to specify ROM files or switches on the command-line.
 
 #### Trace Mode
 
@@ -93,7 +112,7 @@ is running as the emulator is running it. Note however that the speed of
 the emulator will be significantly slower:
 
 ```bash
-java -jar build/libs/yacoco3e-1.0-all.jar file.rom --trace
+java -jar build/libs/yacoco3e-1.0-all.jar --trace
 ```
 
 ## Cassette Tapes
@@ -110,8 +129,12 @@ You can also attach a cassette tape file to the emulator on startup with the
 following:
 
 ```bash
-java -jar build/libs/yacoco3e-1.0-all.jar file.rom --cassette /path/to/cas/file
+java -jar build/libs/yacoco3e-1.0-all.jar --cassette /path/to/cas/file
 ```
+
+See the section on [Configuration File](#configuration-file) for more
+information on how to create a configuration file so that you don't
+have to specify ROM files or switches on the command-line.
  
 #### Writing
 
@@ -131,14 +154,18 @@ of the tape buffer to the actual file. You can to that by clicking the menu item
 ## Disk Drives
 
 The emulator has built-in support for disk drive systems, however, it requires
-a Disk Basic ROM (1.0 or 1.1) to be loaded into the cartridge slot on emulator
-startup with the `--cartridge` switch:
+a Disk Basic ROM (1.0 or 1.1) to be loaded into the cartridge slot on the emulator
+with the `--cartridge` switch:
 
 ```bash
-java -jar build/libs/yacoco3e-1.0-all.jar super-ext-basic.rom --cartridge /path/to/disk/basic/rom
+java -jar build/libs/yacoco3e-1.0-all.jar --cartridge /path/to/disk/basic/rom
 ```
 
 Four virtual disk drives are available by default (drive numbers 0-3).
+
+See the section on [Configuration File](#configuration-file) for more
+information on how to create a configuration file so that you don't
+have to specify ROM files or switches on the command-line.
 
 
 #### Loading a Disk Image
@@ -163,6 +190,53 @@ select a location on your computer where the disk file will be saved to.
 Once entered, the contents of the drive will be saved to the virtual disk
 file, and can be loaded from the host computer in a future session.
 
+
+## Configuration File
+
+The emulator allows you to create a simple configuration file so that
+you do not have to specify arguments on the command line. The configuration
+file is in YAML format, and supports the following keys:
+
+* `systemROM` - the full path to the ROM file to be used as the system ROM (e.g.
+Super Extended Color Basic ROM file).
+* `cartridgeROM` - the full path to the ROM file plugged into the cartridge (e.g.
+Megabug).
+* `cassetteROM` - the full path to the ROM file used in the cassette recorder.
+* `drive0Image` - the `DSK` image to be used in drive 0.
+* `drive1Image` - the `DSK` image to be used in drive 0.
+* `drive2Image` - the `DSK` image to be used in drive 0.
+* `drive3Image` - the `DSK` image to be used in drive 0.
+
+Leaving any one of the keys out will result in the emulator ignoring that particular
+ROM image. An example YAML configuration file that specifies ROMs to use for the
+system, cartridge slot, cassette, and drive 0 is as follows:
+
+```
+systemROM: "C:\Users\basic3.rom"
+cartridgeROM: "C:\disk11.rom"
+cassetteROM: "C:\Users\zaxxon.cas"
+drive0Image: "C:\megabug.dsk"
+```
+
+If you start the emulator without command-line arguments, it will look for a configuration file named
+`config.yml` in the current execution directory. This means you can just run the jar file or
+double click it without specifying anything at the command-line. If you want to specify
+a different configuration file to use, you must pass the `--config` option on the
+command-line:
+
+```
+java -jar build/libs/yacoco3e-1.0-all.jar --config "C:\Users\my-emulator-config.yml"
+```
+
+The order in which the emulator will attempt to interpret ROMs is:
+
+1. Command-line specified ROMs (e.g. the `--cartridge` switch)
+2. Command-line specified configuration file (e.g. with the `--config` switch)
+3. Looking for `config.yml` in the current directory
+
+If none of the options above result in any valid ROMs to use for the system ROM,
+then the emulator will start, but will be in a paused mode. You can then attach
+ROM files manually using the menu system.
 
 ## Keyboard
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     compile 'commons-io:commons-io:2.6'
     compile 'org.apache.commons:commons-lang3:3.6'
     compile 'com.beust:jcommander:1.72'
+    compile 'org.yaml:snakeyaml:1.24'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-all:1.10.19'
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/common/IO.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/common/IO.java
@@ -48,8 +48,10 @@ public class IO
                 }
                 data = tempStream.toByteArray();
                 tempStream.close();
+                stream.close();
             } else {
                 data = IOUtils.toByteArray(stream);
+                stream.close();
             }
             return data;
         } catch (Exception e) {

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/ConfigFile.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/ConfigFile.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2017-2019 Craig Thomas
+ * This project uses an MIT style license - see LICENSE for details.
+ */
+package ca.craigthomas.yacoco3e.datatypes;
+
+import ca.craigthomas.yacoco3e.common.IO;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import java.io.InputStream;
+
+public class ConfigFile
+{
+    private String systemROM;
+    private String cartridgeROM;
+    private String drive0Image;
+    private String drive1Image;
+    private String drive2Image;
+    private String drive3Image;
+    private String cassetteROM;
+
+    public ConfigFile() { }
+
+    public ConfigFile(String system, String cartridge, String drive0, String drive1, String drive2,
+                      String drive3, String cassette) {
+        systemROM = system;
+        cartridgeROM = cartridge;
+        drive0Image = drive0;
+        drive1Image = drive1;
+        drive2Image = drive2;
+        drive3Image = drive3;
+        cassetteROM = cassette;
+    }
+
+    public ConfigFile(String system, String cartridge, String cassette) {
+        systemROM = system;
+        cartridgeROM = cartridge;
+        cassetteROM = cassette;
+    }
+
+    public boolean hasSystemROM() {
+        return systemROM != null;
+    }
+
+    public boolean hasCartridgeROM() {
+        return cartridgeROM != null;
+    }
+
+    public boolean hasCassetteROM() {
+        return cassetteROM != null;
+    }
+
+    public boolean isEmpty() {
+        return (systemROM == null) && (cartridgeROM == null) && (cassetteROM == null) && (drive0Image == null) &&
+                (drive1Image == null) && (drive2Image == null) && (drive3Image == null);
+    }
+
+    public String getSystemROM() {
+        return systemROM;
+    }
+
+    public void setSystemROM(String newSystemROM) {
+        systemROM = newSystemROM;
+    }
+
+    public String getCartridgeROM() {
+        return cartridgeROM;
+    }
+
+    public void setCartridgeROM(String cartridgeROM) {
+        this.cartridgeROM = cartridgeROM;
+    }
+
+    public String getDrive0Image() {
+        return drive0Image;
+    }
+
+    public void setDrive0Image(String drive0Image) {
+        this.drive0Image = drive0Image;
+    }
+
+    public String getDrive1Image() {
+        return drive1Image;
+    }
+
+    public void setDrive1Image(String drive1Image) {
+        this.drive1Image = drive1Image;
+    }
+
+    public String getDrive2Image() {
+        return drive2Image;
+    }
+
+    public void setDrive2Image(String drive2Image) {
+        this.drive2Image = drive2Image;
+    }
+
+    public String getDrive3Image() {
+        return drive3Image;
+    }
+
+    public void setDrive3Image(String drive3Image) {
+        this.drive3Image = drive3Image;
+    }
+
+    public String getCassetteROM() {
+        return cassetteROM;
+    }
+
+    public void setCassetteROM(String cassetteROM) {
+        this.cassetteROM = cassetteROM;
+    }
+
+    /**
+     * Parses a configuration file. Must contain valid YAML.
+     *
+     * @param filename the name of the configuration file to parse
+     * @return a ConfigFile object
+     */
+    public static ConfigFile parseConfigFile(String filename) {
+        if (filename == null) {
+            return null;
+        }
+
+        Yaml configYaml = new Yaml(new Constructor(ConfigFile.class));
+        InputStream stream = IO.openInputStream(filename);
+        if (stream == null) {
+            return null;
+        }
+
+        ConfigFile configFile = configYaml.load(stream);
+        IO.closeStream(stream);
+        return configFile;
+    }
+}

--- a/src/main/java/ca/craigthomas/yacoco3e/runner/Arguments.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/runner/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Craig Thomas
+ * Copyright (C) 2017-2019 Craig Thomas
  * This project uses an MIT style license - see LICENSE for details.
  */
 package ca.craigthomas.yacoco3e.runner;
@@ -11,8 +11,8 @@ import com.beust.jcommander.Parameter;
  */
 public class Arguments
 {
-    @Parameter(description="ROM file")
-    public String romFile;
+    @Parameter(names="--system", description="system ROM")
+    public String systemROM;
 
     @Parameter(names="--scale", description="scale factor")
     public Integer scale = 2;
@@ -26,6 +26,9 @@ public class Arguments
     @Parameter(names="--cassette", description="cassette file")
     public String cassetteFile;
 
-    @Parameter(names="--cartridge", description="Cartridge ROM")
+    @Parameter(names="--cartridge", description="cartridge ROM")
     public String cartridgeROM;
+
+    @Parameter(names="--config", description="path to config file")
+    public String configFile;
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/runner/Runner.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/runner/Runner.java
@@ -26,11 +26,12 @@ public class Runner
         /* Create the emulator and start it running */
         Emulator emulator = new Emulator.Builder()
                 .setScale(arguments.scale)
-                .setSystemROM(arguments.romFile)
+                .setSystemROM(arguments.systemROM)
                 .setTrace(arguments.trace)
                 .setVerbose(arguments.verbose)
                 .setCassetteFile(arguments.cassetteFile)
                 .setCartridgeROM(arguments.cartridgeROM)
+                .setConfigFile(arguments.configFile)
                 .build();
         emulator.start();
     }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/ConfigFileTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/ConfigFileTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2017 Craig Thomas
+ * This project uses an MIT style license - see LICENSE for details.
+ */
+package ca.craigthomas.yacoco3e.components;
+
+import ca.craigthomas.yacoco3e.common.IO;
+import ca.craigthomas.yacoco3e.datatypes.ConfigFile;
+import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+
+public class ConfigFileTest
+{
+    private ConfigFile configFile;
+
+    @Before
+    public void setUp() {
+        configFile = new ConfigFile();
+    }
+
+    @Test
+    public void testHasSystemROMFalseOnEmpty() {
+        assertFalse(configFile.hasSystemROM());
+    }
+
+    @Test
+    public void testHasSystemROMTrueWhenSet() {
+        configFile.setSystemROM("not empty");
+        assertTrue(configFile.hasSystemROM());
+    }
+
+    @Test
+    public void testHasCartridgeROMFalseOnEmpty() {
+        assertFalse(configFile.hasCartridgeROM());
+    }
+
+    @Test
+    public void testHasCartridgeROMTrueWhenSet() {
+        configFile.setCartridgeROM("not empty");
+        assertTrue(configFile.hasCartridgeROM());
+    }
+
+    @Test
+    public void testHasCassetteROMFalseOnEmpty() {
+        assertFalse(configFile.hasCassetteROM());
+    }
+
+    @Test
+    public void testHasCassetteROMTrueWhenSet() {
+        configFile.setCassetteROM("not empty");
+        assertTrue(configFile.hasCassetteROM());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        configFile.setSystemROM("system");
+        configFile.setCartridgeROM("cartridge");
+        configFile.setCassetteROM("cassette");
+        configFile.setDrive0Image("0");
+        configFile.setDrive1Image("1");
+        configFile.setDrive2Image("2");
+        configFile.setDrive3Image("3");
+        assertEquals("system", configFile.getSystemROM());
+        assertEquals("cartridge", configFile.getCartridgeROM());
+        assertEquals("cassette", configFile.getCassetteROM());
+        assertEquals("0", configFile.getDrive0Image());
+        assertEquals("1", configFile.getDrive1Image());
+        assertEquals("2", configFile.getDrive2Image());
+        assertEquals("3", configFile.getDrive3Image());
+    }
+
+    @Test
+    public void testIsEmptyTrueWhenAllEmpty() {
+        assertTrue(configFile.isEmpty());
+    }
+
+    @Test
+    public void testIsEmptyTrueWhenAtLeastOneExists() {
+        configFile.setSystemROM("not empty");
+        assertFalse(configFile.isEmpty());
+        configFile = new ConfigFile();
+
+        configFile.setCartridgeROM("not empty");
+        assertFalse(configFile.isEmpty());
+        configFile = new ConfigFile();
+
+        configFile.setCassetteROM("not empty");
+        assertFalse(configFile.isEmpty());
+        configFile = new ConfigFile();
+
+        configFile.setDrive0Image("not empty");
+        assertFalse(configFile.isEmpty());
+        configFile = new ConfigFile();
+
+        configFile.setDrive1Image("not empty");
+        assertFalse(configFile.isEmpty());
+        configFile = new ConfigFile();
+
+        configFile.setDrive2Image("not empty");
+        assertFalse(configFile.isEmpty());
+        configFile = new ConfigFile();
+
+        configFile.setDrive3Image("not empty");
+        assertFalse(configFile.isEmpty());
+        configFile = new ConfigFile();
+    }
+
+    @Test
+    public void testConstructor1() {
+        configFile = new ConfigFile("system", "cartridge", "cassette");
+        configFile.setSystemROM("system");
+        configFile.setCartridgeROM("cartridge");
+        configFile.setCassetteROM("cassette");
+    }
+
+    @Test
+    public void testConstructor2() {
+        configFile = new ConfigFile("system", "cartridge", "0", "1", "2", "3", "cassette");
+        configFile.setSystemROM("system");
+        configFile.setCartridgeROM("cartridge");
+        configFile.setCassetteROM("cassette");
+        assertEquals("0", configFile.getDrive0Image());
+        assertEquals("1", configFile.getDrive1Image());
+        assertEquals("2", configFile.getDrive2Image());
+        assertEquals("3", configFile.getDrive3Image());
+    }
+
+    @Test
+    public void testParseConfigFileCorrectFormat() {
+        File resourceFile = new File(getClass().getClassLoader().getResource("test_config.yml").getFile());
+        configFile = ConfigFile.parseConfigFile(resourceFile.getPath());
+        assertEquals("system", configFile.getSystemROM());
+        assertEquals("cartridge", configFile.getCartridgeROM());
+        assertEquals("cassette", configFile.getCassetteROM());
+        assertEquals("0", configFile.getDrive0Image());
+        assertEquals("1", configFile.getDrive1Image());
+        assertEquals("2", configFile.getDrive2Image());
+        assertEquals("3", configFile.getDrive3Image());
+    }
+
+    @Test
+    public void testParseConfigFileReturnsNullOnNullInput() {
+        configFile = ConfigFile.parseConfigFile(null);
+        assertNull(configFile);
+    }
+
+    @Test
+    public void testParseConfigFileReturnsNullOnBadFilename() {
+        configFile = ConfigFile.parseConfigFile("/this_directory_does_not_exist/this_file_does_not_exist.yml");
+        assertNull(configFile);
+    }
+}

--- a/src/test/java/ca/craigthomas/yacoco3e/components/EmulatorTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/EmulatorTest.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2017-2019 Craig Thomas
+ * This project uses an MIT style license - see LICENSE for details.
+ */
+package ca.craigthomas.yacoco3e.components;
+
+public class EmulatorTest
+{
+    private Emulator emulator;
+}

--- a/src/test/resources/test_config.yml
+++ b/src/test/resources/test_config.yml
@@ -1,0 +1,7 @@
+systemROM: "system"
+cartridgeROM: "cartridge"
+cassetteROM: "cassette"
+drive0Image: "0"
+drive1Image: "1"
+drive2Image: "2"
+drive3Image: "3"


### PR DESCRIPTION
This PR implements configuration files. A config file is a YAML file with several keys that specify system ROM files. These keys are `systemROM`, `cartridgeROM`, `cassetteROM`, `drive0Image`, `drive1Image`, `drive2Image` and `drive3Image`. The configuration file can be specified on the command line with the new argument `--config`. Alternatively, if no configuration file is specified, a file called `config.yml` is consulted in the current directory. If no `config.yml` file is found, then no configuration is used. Other command-line arguments take precedence over the config file switch and environment search. Unit tests added to cover new `ConfigFile` class. 