### PR TITLE
Fix for DAA

### DIFF
--- a/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
@@ -183,6 +183,14 @@ public class Emulator extends Thread
                 LOGGER.info("Loaded cassette file [" + config.getCassetteROM() + "]");
             }
         }
+
+        String drive0 = config.getDrive0Image();
+        if (drive0 != null) {
+            JV1Disk disk = new JV1Disk();
+            if (disk.loadFile(drive0)) {
+                ioController.disk[0].loadFromVirtualDisk(disk);
+            }
+        }
     }
 
     public void loadROM(String filename) {

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
@@ -932,5 +932,17 @@ public class CPUTest
         assertEquals(new UnsignedByte(0x6C), registerSet.getA());
         cpu.decimalAdditionAdjust();
         assertEquals(new UnsignedByte(0x72), registerSet.getA());
+        assertFalse(io.ccCarrySet());
+    }
+
+    @Test
+    public void testDecimalAdditionAdjustWorksCorrectlyWhenCarrySet() {
+        registerSet.setA(new UnsignedByte(0x55));
+        cpu.addWithCarry(Register.A, new UnsignedByte(0x17));
+        io.setCCCarry();
+        assertEquals(new UnsignedByte(0x6C), registerSet.getA());
+        cpu.decimalAdditionAdjust();
+        assertEquals(new UnsignedByte(0xD2), registerSet.getA());
+        assertTrue(io.ccCarrySet());
     }
 }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
@@ -929,6 +929,7 @@ public class CPUTest
     public void testDecimalAdditionAdjustWorksCorrectly() {
         registerSet.setA(new UnsignedByte(0x55));
         cpu.addWithCarry(Register.A, new UnsignedByte(0x17));
+        assertEquals(new UnsignedByte(0x6C), registerSet.getA());
         cpu.decimalAdditionAdjust();
         assertEquals(new UnsignedByte(0x72), registerSet.getA());
     }


### PR DESCRIPTION
This PR fixes the Decimal Addition Adjust code. Previously, it was adding in the contents of the condition code carry bit into the final result. This was incorrect. Additionally, the condition codes were not updated correctly. This PR fixes that problem, and adds unit tests to prevent regressions.