### PR TITLE
Implement SAM R1 bit set / clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Below are a list of items that are currently working:
 - SAM Display Offset Registers (`$FFC6` - `$FFD3`)
 - SAM TY Bits (`$FFDE`, `$FFDF`) 
 - SAM Mode Registers (`$FFC0` - `$FFC5`)
+- SAM R1 Clock Speed Bits (`FFD8`, `FFD9`)
 - VDG Register (`$FF22`)
 - Cassette tape interface
 - IRQ Interrupts (both PIA and GIME)

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
@@ -19,7 +19,6 @@ import javax.swing.UIManager.*;
 public class Emulator extends Thread
 {
     /* Pre-defined constants */
-    private final static int LOW_SPEED_CLOCK_FREQUENCY = 14917;
     private final static long SCREEN_REFRESH_RATE = 17L;
 
     /* The main emulator components */
@@ -400,13 +399,18 @@ public class Emulator extends Thread
         canvas.getBufferStrategy().show();
     }
 
+    /**
+     * Refreshes the number of ticks that can be consumed during the current
+     * 60th of a second time slice.
+     */
     public void refreshTicks() {
-        remainingTicks = LOW_SPEED_CLOCK_FREQUENCY;
+        remainingTicks = ioController.tickRefreshAmount;
     }
 
     /**
      * Starts the main emulator loop running. Fires at the rate of 60Hz,
-     * will repaint the screen and listen for any debug key presses.
+     * will repaint the screen, listen for any debug key presses, and
+     * refresh the number of ticks available to be consumed.
      */
     public void start() {
         this.reset();

--- a/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
@@ -968,6 +968,21 @@ public class IOControllerTest
     }
 
     @Test
+    public void testSAMR1SetHighSpeed() {
+        io.writeByte(new UnsignedWord(0xFFD9), new UnsignedByte(0));
+        assertEquals(new UnsignedByte(0x02), io.samClockSpeed);
+        assertEquals(IOController.HIGH_SPEED_CLOCK_FREQUENCY, io.tickRefreshAmount);
+    }
+
+    @Test
+    public void testSAMR1SetClearHighSpeed() {
+        io.writeByte(new UnsignedWord(0xFFD9), new UnsignedByte(0));
+        io.writeByte(new UnsignedWord(0xFFD8), new UnsignedByte(0));
+        assertEquals(new UnsignedByte(0x00), io.samClockSpeed);
+        assertEquals(IOController.LOW_SPEED_CLOCK_FREQUENCY, io.tickRefreshAmount);
+    }
+
+    @Test
     public void testResetSetsCorrectValues() {
         memory.rom = new short [0x4000];
         memory.rom[0x3FFE] = (short) 0xC0;


### PR DESCRIPTION
This PR implements a set / clear function for the SAM R1 clock speed bit. The R1 bit effectively controls the clock speed for the processor. Writing any value to `FFD8` clears the bit, forcing the processor to run at 0.895 MHz. Writing any value to `FFD9` sets the bit, forcing the processor to run at 1.78 MHz. All control logic has been incorporated into the `IOController` class, leaving it up to the `Emulator` class to simply check the `IOController` for the number of ticks that can be refreshed at each cycle of the 60 Hz tick refresh. Unit tests updated to cover new functionality. This PR closes #50 