### PR TITLE
Add ROM PAR mapping quirk to the MMU

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,7 @@ name: Build Test Coverage
 on: [push, pull_request]
 jobs:
   run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -18,4 +18,4 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v4.2.0
       env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,4 +16,6 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
     - name: Codecov
-      uses: codecov/codecov-action@v3.1.0
+      uses: codecov/codecov-action@v4.2.0
+      env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,6 +16,6 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
     - name: Codecov
-      uses: codecov/codecov-action@v4.2.0
+      uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Memory.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Memory.java
@@ -318,24 +318,61 @@ public class Memory
 
     /**
      * Sets the EXECUTIVE page address register to the specified value.
+     * Note that ROM pages $3C - $3F are a special case - the effective
+     * page written to the par is the high 6 bits of the page requested,
+     * with the bottom two bits of the slot requested.
      *
      * @param par the PAR number to set
      * @param value the value to set it to
      */
     public void setExecutivePAR(int par, UnsignedByte value) {
+        switch (value.getShort()) {
+            case 0x3C:
+            case 0x3D:
+            case 0x3E:
+            case 0x3F:
+                value.and(~0x3);
+                value.or(par & 0x3);
+                break;
+
+            default:
+                break;
+        }
         executivePAR[par] = value.getShort();
     }
 
     /**
      * Sets the TASK page address register to the specified value.
+     * Note that ROM pages $3C - $3F are a special case - the effective
+     * page written to the par is the high 6 bits of the page requested,
+     * with the bottom two bits of the slot requested.
      *
      * @param par the PAR number to set
      * @param value the value to set it to
      */
     public void setTaskPAR(int par, UnsignedByte value) {
+        switch (value.getShort()) {
+            case 0x3C:
+            case 0x3D:
+            case 0x3E:
+            case 0x3F:
+                value.and(~0x3);
+                value.or(par & 0x3);
+                break;
+
+            default:
+                break;
+        }
         taskPAR[par] = value.getShort();
     }
 
+    /**
+     * A convenience function for reading a byte by specifying the address
+     * as an integer instead of an UnsignedWord.
+     *
+     * @param address an integer address to read from
+     * @return an UnsignedByte from the specified location
+     */
     public UnsignedByte readByte(int address) {
         return readByte(new UnsignedWord(address));
     }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/MemoryTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/MemoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Craig Thomas
+ * Copyright (C) 2017-2025 Craig Thomas
  * This project uses an MIT style license - see LICENSE for details.
  */
 package ca.craigthomas.yacoco3e.components;
@@ -21,7 +21,7 @@ public class MemoryTest
 
     @Test
     public void testDefaultConstructorSetsSizeTo512K() {
-        assertEquals(memory.memory.length, Memory.MEM_512K);
+        assertEquals(Memory.MEM_512K, memory.memory.length);
     }
 
     @Test
@@ -34,7 +34,7 @@ public class MemoryTest
     @Test
     public void testWriteByteWritesCorrectByte() {
         memory.writeByte(new UnsignedWord(0xBEEF), new UnsignedByte(0xAB));
-        assertEquals(memory.memory[0x7BEEF], 0xAB);
+        assertEquals(0xAB, memory.memory[0x7BEEF]);
     }
 
     @Test
@@ -72,6 +72,13 @@ public class MemoryTest
     }
 
     @Test
+    public void testSetExecutiveParROMPagesQuirks() {
+        UnsignedByte requestedPage = new UnsignedByte(0x3D);
+        memory.setExecutivePAR(2, requestedPage);
+        assertEquals(0x3E, memory.executivePAR[2]);
+    }
+
+    @Test
     public void testSetTaskPARWorksCorrectly() {
         memory.setTaskPAR(0, new UnsignedByte(0xB1));
         assertEquals(0xB1, memory.taskPAR[0]);
@@ -96,6 +103,13 @@ public class MemoryTest
 
         memory.setTaskPAR(7, new UnsignedByte(0xB8));
         assertEquals(0xB8, memory.taskPAR[7]);
+    }
+
+    @Test
+    public void testSetTaskParROMPagesQuirks() {
+        UnsignedByte requestedPage = new UnsignedByte(0x3D);
+        memory.setTaskPAR(2, requestedPage);
+        assertEquals(0x3E, memory.taskPAR[2]);
     }
 
     @Test


### PR DESCRIPTION
This PR implements a ROM mapping quirk to the MMU. With ROM pages `$3C` to `$3F`, the mapping of the page to a task or executive PAR contains a quirk - the page requested uses the upper 6 bits from the page specified, but the bottom 2 bits from the slot that it is mapped into. This means that if page `$3D` is mapped to slot 2, the _effective_ page mapped to slot 2 is `$3E`. Unit tests added to catch new conditions.
