### PR TITLE
Trace mode menu item

### DIFF
--- a/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Emulator.java
@@ -37,7 +37,7 @@ public class Emulator extends Thread
     private JMenuBar menuBar;
 
     /* State variables */
-    private boolean trace;
+    public boolean trace;
     private boolean verbose;
     private volatile EmulatorStatus status;
     private volatile int remainingTicks;
@@ -335,6 +335,18 @@ public class Emulator extends Thread
 
         menuBar.add(keyboardMenu);
 
+        // Debug menu
+        JMenu debugMenu = new JMenu("Debugging");
+        debugMenu.setMnemonic(KeyEvent.VK_U);
+
+        JRadioButtonMenuItem traceMenuItem = new JRadioButtonMenuItem("Trace");
+        traceMenuItem.setSelected(trace);
+        debugMenu.add(traceMenuItem);
+
+        traceMenuItem.addActionListener(new SetTraceActionListener(this, traceMenuItem));
+
+        menuBar.add(debugMenu);
+
         attachCanvas();
     }
 
@@ -451,18 +463,14 @@ public class Emulator extends Thread
                 /* Increment timers if necessary */
                 io.timerTick(operationTicks);
 
-//                System.out.print(" new pc: " + ioController.regs.pc);
-
                 /* Fire interrupts if set */
                 cpu.serviceInterrupts();
 
                 /* Check to see if we should trace the output */
                 if (this.trace) {
-//                    System.out.print("PC:" + cpu.getLastPC() + " | OP:"
-//                            + cpu.getLastOperand() + " | " + cpu.instruction.getShortDescription());
                     if (cpu.instruction != null) {
                         System.out.print(cpu.instruction.getShortDescription());
-                        System.out.print(" new pc: " + io.regs.pc);
+                        System.out.print(" (New PC: " + io.regs.pc + ")");
                         System.out.println();
                     }
                 }

--- a/src/main/java/ca/craigthomas/yacoco3e/listeners/SetPassthroughKeyboardActionListener.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/listeners/SetPassthroughKeyboardActionListener.java
@@ -32,10 +32,6 @@ public class SetPassthroughKeyboardActionListener extends AbstractFileChooserLis
         setPassthroughKeyboard();
     }
 
-    /**
-     * Opens a dialog box to prompt the user to choose a cassette file
-     * to open for playback.
-     */
     public void setPassthroughKeyboard() {
         emulator.switchKeyListener(new PassthroughKeyboard());
         emulated.setSelected(false);

--- a/src/main/java/ca/craigthomas/yacoco3e/listeners/SetTraceActionListener.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/listeners/SetTraceActionListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Craig Thomas
+ * This project uses an MIT style license - see LICENSE for details.
+ */
+package ca.craigthomas.yacoco3e.listeners;
+
+import ca.craigthomas.yacoco3e.components.Emulator;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * An ActionListener that will start or stop debug tracing.
+ */
+public class SetTraceActionListener implements ActionListener
+{
+    private Emulator emulator;
+    private JRadioButtonMenuItem traceMenuItem;
+
+    public SetTraceActionListener(Emulator emulator, JRadioButtonMenuItem traceMenuItem) {
+        super();
+        this.emulator = emulator;
+        this.traceMenuItem = traceMenuItem;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        setTrace();
+    }
+
+    public void setTrace() {
+        emulator.trace = !emulator.trace;
+        traceMenuItem.setSelected(emulator.trace);
+    }
+
+}


### PR DESCRIPTION
This PR adds a trace mode menu item to the emulator. The menu item is found under a "Debugging" heading. The toggle will immediately start or stop trace output to the standard out device. 