### PR TITLE
Implement PIA device selector plus CPU fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ group = 'ca.craigthomas'
 version = '1.0'
 
 java {
-    sourceCompatibility = 1.8
+    sourceCompatibility = JavaVersion.VERSION_17
 }
 
 application {

--- a/src/main/java/ca/craigthomas/yacoco3e/components/BranchInstruction.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/BranchInstruction.java
@@ -37,7 +37,7 @@ public class BranchInstruction extends Instruction
 
     public int call(IOController io) {
         if (operation.apply(io).equals(true)) {
-            io.regs.pc.add(byteRead.isNegative() ? byteRead.getSignedShort() : byteRead.getShort());
+            io.regs.pc.add(byteRead.isNegative() ? byteRead.getSigned() : byteRead.get());
         }
         return ticks;
     }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/ByteInstruction.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/ByteInstruction.java
@@ -51,28 +51,11 @@ public class ByteInstruction extends Instruction
      */
     public static void negate(IOController io, UnsignedByte memoryByte, UnsignedWord address) {
         io.regs.cc.and(~(CC_N | CC_Z | CC_V | CC_C));
-
-        if (memoryByte.equalsInt(0x80)) {
-            io.regs.cc.or(CC_V);
-            io.regs.cc.or(CC_N);
-            io.regs.cc.or(CC_C);
-            memoryByte.set(0x80);
-            io.writeByte(address, memoryByte);
-            return;
-        }
-
-        if (memoryByte.equalsInt(0x00)) {
-            io.regs.cc.or(CC_Z);
-            memoryByte.set(0);
-            io.writeByte(address, memoryByte);
-            return;
-        }
-
-        memoryByte.compliment();
-        memoryByte.add(1);
-        io.regs.cc.or(memoryByte.isMasked(0x80) ? CC_V : 0);
+        io.regs.cc.or(memoryByte.get() == 0x80 ? CC_V : 0);
+        io.regs.cc.or(memoryByte.get() != 0x00 ? CC_C : 0);
+        memoryByte.set(0x100 - memoryByte.get());
         io.regs.cc.or(memoryByte.isNegative() ? CC_N : 0);
-        io.regs.cc.or(CC_C);
+        io.regs.cc.or(memoryByte.isZero() ? CC_Z : 0);
         io.writeByte(address, memoryByte);
     }
 

--- a/src/main/java/ca/craigthomas/yacoco3e/components/DeviceSelectorSwitch.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/DeviceSelectorSwitch.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2025 Craig Thomas
+ * This project uses an MIT style license - see LICENSE for details.
+ */
 package ca.craigthomas.yacoco3e.components;
 
 public class DeviceSelectorSwitch
@@ -15,16 +19,10 @@ public class DeviceSelectorSwitch
     public void setCB2(boolean isSet) {
         CB2 = (isSet) ? 1 : 0;
         switchPosition = (CB2 << 1) + CA2;
-        System.out.println("New switch position = " + switchPosition);
     }
 
     public void setCA2(boolean isSet) {
         CA2 = (isSet) ? 1 : 0;
         switchPosition = (CB2 << 1) + CA2;
-        System.out.println("New switch position = " + switchPosition);
-    }
-
-    public int getSwitchPosition() {
-        return switchPosition;
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/DeviceSelectorSwitch.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/DeviceSelectorSwitch.java
@@ -1,0 +1,30 @@
+package ca.craigthomas.yacoco3e.components;
+
+public class DeviceSelectorSwitch
+{
+    protected int switchPosition;
+    protected int CB2;
+    protected int CA2;
+
+    public DeviceSelectorSwitch() {
+        switchPosition = 0;
+        CB2 = 0;
+        CA2 = 0;
+    }
+
+    public void setCB2(boolean isSet) {
+        CB2 = (isSet) ? 1 : 0;
+        switchPosition = (CB2 << 1) + CA2;
+        System.out.println("New switch position = " + switchPosition);
+    }
+
+    public void setCA2(boolean isSet) {
+        CA2 = (isSet) ? 1 : 0;
+        switchPosition = (CB2 << 1) + CA2;
+        System.out.println("New switch position = " + switchPosition);
+    }
+
+    public int getSwitchPosition() {
+        return switchPosition;
+    }
+}

--- a/src/main/java/ca/craigthomas/yacoco3e/components/DigitalAnalogConverter.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/DigitalAnalogConverter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025 Craig Thomas
+ * This project uses an MIT style license - see LICENSE for details.
+ */
+package ca.craigthomas.yacoco3e.components;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.DataLine;
+import javax.sound.sampled.SourceDataLine;
+import java.util.Arrays;
+
+public class DigitalAnalogConverter extends Thread
+{
+    public static final int LINE_BUFFER_SIZE = 2000;
+    public static final int AUDIO_BUFFER_SIZE = 100;
+    public static final float AUDIO_PLAYBACK_RATE = 44100.0f;
+
+    protected AudioFormat audioFormat;
+    protected SourceDataLine audioOutputLine;
+    protected volatile byte [] audioBuffer;
+    protected Cassette cassette;
+    protected volatile byte sample;
+    protected boolean play;
+    protected boolean running;
+
+    public DigitalAnalogConverter() {
+        sample = 0;
+        audioFormat = new AudioFormat(AUDIO_PLAYBACK_RATE, 8, 1, true, false);
+        audioBuffer = new byte [AUDIO_BUFFER_SIZE];
+        DataLine.Info dataLineInfo = new DataLine.Info(SourceDataLine.class, audioFormat);
+        if (!AudioSystem.isLineSupported(dataLineInfo)) {
+            System.out.println("SourceDataLine type not supported");
+        }
+        try {
+            audioOutputLine = AudioSystem.getSourceDataLine(audioFormat);
+            audioOutputLine.open(audioFormat, LINE_BUFFER_SIZE);
+            audioOutputLine.start();
+            System.out.println("Instantiated DAC");
+        } catch (Exception e) {
+            System.out.println("Could not get source data line");
+            audioOutputLine = null;
+        }
+        play = true;
+    }
+
+    public void writeByte(byte digitalSample) {
+        if (digitalSample == 0) {
+            setPlay(false);
+            return;
+        }
+        setPlay(true);
+        Arrays.fill(audioBuffer, digitalSample);
+    }
+
+    public void setPlay(boolean newPlayStatus) {
+        play = newPlayStatus;
+        if (!play && audioOutputLine != null) {
+            audioOutputLine.flush();
+        }
+    }
+
+    public void stopRunning() {
+        running = false;
+    }
+
+    public void run() {
+        running = true;
+        while (running) {
+            if (play && audioOutputLine != null) {
+//                audioOutputLine.flush();
+                audioOutputLine.write(audioBuffer, 0, AUDIO_BUFFER_SIZE);
+            }
+        }
+        shutdown();
+    }
+
+    /**
+     * Close down audio resources.
+     */
+    public void shutdown() {
+        if (audioOutputLine != null) {
+            audioOutputLine.flush();
+            audioOutputLine.stop();
+            audioOutputLine.close();
+        }
+    }
+}

--- a/src/main/java/ca/craigthomas/yacoco3e/components/DiskDrive.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/DiskDrive.java
@@ -119,7 +119,7 @@ public class DiskDrive
      * @param track the track to move to
      */
     public void setTrack(UnsignedByte track) {
-        currentTrack = track.getShort();
+        currentTrack = track.get();
     }
 
     /**
@@ -137,7 +137,7 @@ public class DiskDrive
      * @param sector the current sector we should move to
      */
     public void setSector(UnsignedByte sector) {
-        currentSector = sector.getShort();
+        currentSector = sector.get();
     }
 
     /**
@@ -314,7 +314,7 @@ public class DiskDrive
      * @param command the command to execute
      */
     public void executeCommand(UnsignedByte command) {
-        int intCommand = command.getShort() >> 4;
+        int intCommand = command.get() >> 4;
         boolean verify = command.isMasked(0x04);
 
         /* Set busy flag on the status register */
@@ -489,7 +489,7 @@ public class DiskDrive
      * @param verify whether verify should be run
      */
     public void seek(boolean verify) {
-        int trackToSeek = dataRegisterIn.getShort();
+        int trackToSeek = dataRegisterIn.get();
         if (currentTrack > trackToSeek) {
             direction = -1;
         }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/DiskTrack.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/DiskTrack.java
@@ -50,7 +50,7 @@ public class DiskTrack
      * @param value the value to write to the sector
      */
     public void writeData(int sector, UnsignedByte value) {
-        sectors[sector].writeSectorData((byte) value.getShort());
+        sectors[sector].writeSectorData((byte) value.get());
     }
 
     /**
@@ -115,7 +115,7 @@ public class DiskTrack
      * @param mark the value of the mark
      */
     public void writeDataMark(int sector, UnsignedByte mark) {
-        sectors[sector].writeDataMark((byte) mark.getShort());
+        sectors[sector].writeDataMark((byte) mark.get());
     }
 
     /**
@@ -201,7 +201,7 @@ public class DiskTrack
         }
 
         /* Check to see if we have a byte that has a different interpretation */
-        byte byteValue = (byte) value.getShort();
+        byte byteValue = (byte) value.get();
         if (doubleDensity) {
             switch (byteValue) {
                 case (byte) 0xF5:
@@ -267,6 +267,6 @@ public class DiskTrack
     }
 
     public void writeSectorId(int sector, UnsignedByte value) {
-        sectors[sector].writeId((byte) value.getShort());
+        sectors[sector].writeId((byte) value.get());
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
@@ -46,14 +46,8 @@ public class IOController
     protected PIA2a pia2a;
     protected PIA2b pia2b;
 
-    /* PIA2 */
-    protected UnsignedByte pia2DRA;  /* PIA 2 Data Register A */
-    protected UnsignedByte pia2CRA;  /* PIA 2 Control Register A*/
-    protected UnsignedByte pia2DDRA; /* PIA 2 Data Direction Register A */
-
-    protected UnsignedByte pia2DRB;
-    protected UnsignedByte pia2CRB;
-    protected UnsignedByte pia2DDRB;
+    /* Device Selector */
+    protected DeviceSelectorSwitch deviceSelectorSwitch;
 
     /* Video mode related functions */
     protected UnsignedByte samControlBits;
@@ -118,25 +112,18 @@ public class IOController
         /* Screen controls */
         samControlBits = new UnsignedByte();
 
+        /* Device Selector */
+        deviceSelectorSwitch = new DeviceSelectorSwitch();
+
         /* PIAs */
-        pia1a = new PIA1a(keyboard);
-        pia1b = new PIA1b(keyboard);
+        pia1a = new PIA1a(keyboard, deviceSelectorSwitch);
+        pia1b = new PIA1b(keyboard, deviceSelectorSwitch);
         pia2a = new PIA2a(cassette);
         pia2b = new PIA2b(this);
 
         /* Display registers */
         verticalOffsetRegister = new UnsignedWord(0x0400);
         samDisplayOffsetRegister = new UnsignedByte(0x0);
-
-        /* PIAs */
-
-        pia2CRA = new UnsignedByte(0);
-        pia2DRA = new UnsignedByte(0);
-        pia2DDRA = new UnsignedByte(0);
-
-        pia2CRB = new UnsignedByte(0);
-        pia2DRB = new UnsignedByte(0);
-        pia2DDRB = new UnsignedByte(0);
 
         /* Interrupts */
         irqStatus = new UnsignedByte();

--- a/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
@@ -102,7 +102,7 @@ public class IOController
     public volatile int tickRefreshAmount;
 
 
-    public IOController(Memory memory, RegisterSet registerSet, Keyboard keyboard, Screen screen, Cassette cassette, SourceDataLine audioOutputLine) {
+    public IOController(Memory memory, RegisterSet registerSet, Keyboard keyboard, Screen screen, Cassette cassette, boolean useDAC) {
         ioMemory = new short[IO_ADDRESS_SIZE];
         this.memory = memory;
         this.regs = registerSet;
@@ -120,7 +120,7 @@ public class IOController
         /* PIAs */
         pia1a = new PIA1a(keyboard, deviceSelectorSwitch);
         pia1b = new PIA1b(keyboard, deviceSelectorSwitch);
-        pia2a = new PIA2a(cassette, audioOutputLine);
+        pia2a = new PIA2a(cassette, useDAC);
         pia2b = new PIA2b(this);
 
         /* Display registers */
@@ -1247,5 +1247,11 @@ public class IOController
      */
     public void nonMaskableInterrupt() {
         cpu.scheduleNMI();
+    }
+
+    public void shutdown() {
+        if (pia2a != null) {
+            pia2a.shutdown();
+        }
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
@@ -763,31 +763,37 @@ public class IOController
             /* SAM - Video Display - V0 - Clear */
             case 0xFFC0:
                 samControlBits.and(~0x1);
+                updateVideoMode(pia2b.getVdgMode());
                 break;
 
             /* SAM - Video Display - V0 - Set */
             case 0xFFC1:
                 samControlBits.or(0x1);
+                updateVideoMode(pia2b.getVdgMode());
                 break;
 
             /* SAM - Video Display - V1 - Clear */
             case 0xFFC2:
                 samControlBits.and(~0x2);
+                updateVideoMode(pia2b.getVdgMode());
                 break;
 
             /* SAM - Video Display - V1 - Set */
             case 0xFFC3:
                 samControlBits.or(0x2);
+                updateVideoMode(pia2b.getVdgMode());
                 break;
 
             /* SAM - Video Display - V2 - Clear */
             case 0xFFC4:
                 samControlBits.and(~0x4);
+                updateVideoMode(pia2b.getVdgMode());
                 break;
 
             /* SAM - Video Display - V2 - Set */
             case 0xFFC5:
                 samControlBits.or(0x4);
+                updateVideoMode(pia2b.getVdgMode());
                 break;
 
             /* SAM - Display Offset Register - Bit 0 - Clear */
@@ -974,8 +980,6 @@ public class IOController
                     break;
 
                 default:
-                    UnsignedByte fullMode = new UnsignedByte(vdgOperatingMode.get() + samControlBits.get());
-                    System.out.println("Unknown screen mode: " + fullMode);
                     return;
             }
         } else {
@@ -997,8 +1001,6 @@ public class IOController
                     break;
 
                 default:
-                    UnsignedByte fullMode = new UnsignedByte(vdgOperatingMode.get() + samControlBits.get());
-                    System.out.println("Unknown screen mode: " + fullMode);
                     return;
             }
         }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/InstructionTable.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/InstructionTable.java
@@ -800,7 +800,7 @@ public class InstructionTable
      * @return the Opcode object associated with the opcode read
      */
     public static Instruction get(UnsignedWord operand) {
-        int value = operand.getInt();
+        int value = operand.get();
 
         if ((value & 0xFF00) == 0x1000) {
             return EXTENDED_INSTRUCTIONS[value & 0x00FF];

--- a/src/main/java/ca/craigthomas/yacoco3e/components/LongBranchInstruction.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/LongBranchInstruction.java
@@ -33,7 +33,7 @@ public class LongBranchInstruction extends BranchInstruction
     @Override
     public int call(IOController io) {
         if (operation.apply(io).equals(true)) {
-            io.regs.pc.add(wordRead.isNegative() ? wordRead.getSignedInt() : wordRead.getInt());
+            io.regs.pc.add(wordRead.isNegative() ? wordRead.getSignedInt() : wordRead.get());
             return ticks + 1;
         }
         return ticks;

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Memory.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Memory.java
@@ -108,7 +108,7 @@ public class Memory
      */
 
     public int getPAR(UnsignedWord address) {
-        return address.getInt() >> 13;
+        return address.get() >> 13;
     }
 
     /**
@@ -118,7 +118,7 @@ public class Memory
      * @return the short value of the byte read
      */
     public short readPhysicalByte(UnsignedWord address) {
-        int intAddress = address.getInt();
+        int intAddress = address.get();
         int par = getPAR(address);
 
         /* Grab the PAR to read from (if MMU enabled) */
@@ -219,12 +219,12 @@ public class Memory
      * @param value the UnsignedByte to write
      */
     public void writeByte(UnsignedWord address, UnsignedByte value) {
-        int intAddress = address.getInt();
+        int intAddress = address.get();
         int par = getPAR(address);
 
         /* RAM only */
         if (allRAMMode) {
-            memory[getPhysicalAddress(par, intAddress)] = value.getShort();
+            memory[getPhysicalAddress(par, intAddress)] = value.get();
             return;
         }
 
@@ -237,7 +237,7 @@ public class Memory
                 return;
 
             default:
-                memory[getPhysicalAddress(par, intAddress)] = value.getShort();
+                memory[getPhysicalAddress(par, intAddress)] = value.get();
         }
     }
 
@@ -326,7 +326,7 @@ public class Memory
      * @param value the value to set it to
      */
     public void setExecutivePAR(int par, UnsignedByte value) {
-        switch (value.getShort()) {
+        switch (value.get()) {
             case 0x3C:
             case 0x3D:
             case 0x3E:
@@ -338,7 +338,7 @@ public class Memory
             default:
                 break;
         }
-        executivePAR[par] = value.getShort();
+        executivePAR[par] = value.get();
     }
 
     /**
@@ -351,7 +351,7 @@ public class Memory
      * @param value the value to set it to
      */
     public void setTaskPAR(int par, UnsignedByte value) {
-        switch (value.getShort()) {
+        switch (value.get()) {
             case 0x3C:
             case 0x3D:
             case 0x3E:
@@ -363,7 +363,7 @@ public class Memory
             default:
                 break;
         }
-        taskPAR[par] = value.getShort();
+        taskPAR[par] = value.get();
     }
 
     /**

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA.java
@@ -47,7 +47,7 @@ public abstract class PIA
      * @param newDataDirectionRegister the new contents fo the data direction register
      */
     public void setDataDirectionRegister(UnsignedByte newDataDirectionRegister) {
-        dataDirectionRegister = newDataDirectionRegister;
+        dataDirectionRegister = newDataDirectionRegister.copy();
     }
 
     /**

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA.java
@@ -26,7 +26,7 @@ public abstract class PIA
     public abstract UnsignedByte getDataRegister();
 
     /**
-     * Sets the data regiister for this portion of the PIA.
+     * Sets the data register for this portion of the PIA.
      *
      * @param newDataRegister the new value for the data register
      */
@@ -38,7 +38,7 @@ public abstract class PIA
      * @return the data direction register contents
      */
     public UnsignedByte getDataDirectionRegister() {
-        return dataDirectionRegister;
+        return dataDirectionRegister.copy();
     }
 
     /**
@@ -78,6 +78,7 @@ public abstract class PIA
      * @return the data register or the data direction register
      */
     public UnsignedByte getRegister() {
+        controlRegister.and(controlRegister.isMasked(0x04) ? ~0xC0 : ~0x00);
         return (controlRegister.isMasked(0x04)) ? getDataRegister() : getDataDirectionRegister();
     }
 

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA1a.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA1a.java
@@ -12,12 +12,14 @@ import static ca.craigthomas.yacoco3e.datatypes.RegisterSet.CC_I;
 public class PIA1a extends PIA
 {
     protected Keyboard keyboard;
+    protected DeviceSelectorSwitch deviceSelectorSwitch;
     protected int timerValue;
 
-    public PIA1a(Keyboard newKeyboard) {
+    public PIA1a(Keyboard newKeyboard, DeviceSelectorSwitch newDeviceSelectorSwitch) {
         super();
         keyboard = newKeyboard;
         timerValue = 0;
+        deviceSelectorSwitch = newDeviceSelectorSwitch;
     }
 
     /**
@@ -50,9 +52,19 @@ public class PIA1a extends PIA
      */
     @Override
     public void setControlRegister(UnsignedByte newControlRegister) {
-        controlRegister = new UnsignedByte(newControlRegister.getShort() +
+        controlRegister = new UnsignedByte(
+                newControlRegister.getShort() +
                         (controlRegister.isMasked(0x80) ? 0x80 : 0) +
-                        (controlRegister.isMasked(0x40) ? 0x40 : 0));
+                        (controlRegister.isMasked(0x40) ? 0x40 : 0)
+        );
+
+        // Bit 5=1 - CA2 is an output
+        if (controlRegister.isMasked(0x10)) {
+            // Bit 4=1 - Output a signal directly on CA2 based on Bit 3 value
+            if (controlRegister.isMasked(0x8)) {
+                deviceSelectorSwitch.setCA2(controlRegister.isMasked(0x4));
+            }
+        }
     }
 
     /**

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA1a.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA1a.java
@@ -53,7 +53,7 @@ public class PIA1a extends PIA
     @Override
     public void setControlRegister(UnsignedByte newControlRegister) {
         controlRegister = new UnsignedByte(
-                newControlRegister.getShort() +
+                newControlRegister.get() +
                         (controlRegister.isMasked(0x80) ? 0x80 : 0) +
                         (controlRegister.isMasked(0x40) ? 0x40 : 0)
         );

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA1a.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA1a.java
@@ -30,7 +30,6 @@ public class PIA1a extends PIA
      */
     @Override
     public UnsignedByte getDataRegister() {
-        controlRegister.and(~0xC0);
         return keyboard.getHighByte();
     }
 

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA1b.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA1b.java
@@ -54,7 +54,7 @@ public class PIA1b extends PIA
     @Override
     public void setControlRegister(UnsignedByte newControlRegister) {
         controlRegister = new UnsignedByte(
-                newControlRegister.getShort() +
+                newControlRegister.get() +
                 (controlRegister.isMasked(0x80) ? 0x80 : 0) +
                 (controlRegister.isMasked(0x40) ? 0x40 : 0)
         );

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA1b.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA1b.java
@@ -12,11 +12,13 @@ import static ca.craigthomas.yacoco3e.datatypes.RegisterSet.CC_I;
 public class PIA1b extends PIA
 {
     protected Keyboard keyboard;
+    protected DeviceSelectorSwitch deviceSelectorSwitch;
     protected int timerValue;
 
-    public PIA1b(Keyboard newKeyboard) {
+    public PIA1b(Keyboard newKeyboard, DeviceSelectorSwitch newDeviceSelectorSwitch) {
         super();
         keyboard = newKeyboard;
+        deviceSelectorSwitch = newDeviceSelectorSwitch;
         timerValue = 0;
     }
 
@@ -56,6 +58,14 @@ public class PIA1b extends PIA
                 (controlRegister.isMasked(0x80) ? 0x80 : 0) +
                 (controlRegister.isMasked(0x40) ? 0x40 : 0)
         );
+
+        // Bit 5=1 - CB2 is an output
+        if (controlRegister.isMasked(0x10)) {
+            // Bit 4=1 - Output a signal directly on CB2 based on Bit 3 value
+            if (controlRegister.isMasked(0x8)) {
+                deviceSelectorSwitch.setCB2(controlRegister.isMasked(0x4));
+            }
+        }
     }
 
     /**

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA1b.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA1b.java
@@ -30,7 +30,6 @@ public class PIA1b extends PIA
      */
     @Override
     public UnsignedByte getDataRegister() {
-        controlRegister.and(~0xC0);
         return keyboard.getLowByte();
     }
 

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA2a.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA2a.java
@@ -64,8 +64,8 @@ public class PIA2a extends PIA
         voltage += newDataRegister.isMasked(0x04) ? 0.070f : 0.0f;
 
 //        System.out.println("New voltage " + voltage);
-        byte audioByte = (byte)((voltage / 4.5) * 128);
-        System.out.println("New audio byte " + audioByte);
+        byte audioByte = (byte)((voltage / 4.5f) * 128.0f);
+//        System.out.println("New audio byte " + audioByte);
         Arrays.fill(audioBuffer, audioByte);
 
         if (audioOutputLine != null) {

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA2a.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA2a.java
@@ -6,13 +6,22 @@ package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
 
+import javax.sound.sampled.*;
+import java.util.Arrays;
+
 public class PIA2a extends PIA
 {
+    protected SourceDataLine audioOutputLine;
+    protected byte [] audioBuffer;
     protected Cassette cassette;
+    protected float voltage;
 
-    public PIA2a(Cassette newCassette) {
+    public PIA2a(Cassette newCassette, SourceDataLine sourceDataLine) {
         super();
         cassette = newCassette;
+        voltage = 0.0f;
+        audioOutputLine = sourceDataLine;
+        audioBuffer = new byte[Emulator.MIN_AUDIO_SAMPLES];
     }
 
     /**
@@ -29,13 +38,40 @@ public class PIA2a extends PIA
     }
 
     /**
-     * In the Color Computer line of computers, PIA 1 side A is always configured for
-     * input, not for output. Writing to the data register does nothing.
+     * In the Color Computer line of computers, PIA 2 side A is always configured for
+     * output, not for input. Writing to the data register writes a value to the
+     * digital-to-analog converter. A corresponding voltage is generated from the
+     * values written from bits 2 through 7 of the data register. The resulting
+     * voltage ranges from 0 to +4.5V. Each bit has an additive contribution to
+     * the overall voltage as follows:
+     *   bit 7 set = 2.250V
+     *   bit 6 set = 1.125V
+     *   bit 5 set = 0.563V
+     *   bit 4 set = 0.281V
+     *   bit 3 set = 0.140V
+     *   bit 2 set = 0.070V
      *
      * @param newDataRegister the new value for the data register
      */
     @Override
     public void setDataRegister(UnsignedByte newDataRegister) {
+        voltage = 0.0f;
+        voltage += newDataRegister.isMasked(0x80) ? 2.250f : 0.0f;
+        voltage += newDataRegister.isMasked(0x40) ? 1.125f : 0.0f;
+        voltage += newDataRegister.isMasked(0x20) ? 0.563f : 0.0f;
+        voltage += newDataRegister.isMasked(0x10) ? 0.281f : 0.0f;
+        voltage += newDataRegister.isMasked(0x08) ? 0.140f : 0.0f;
+        voltage += newDataRegister.isMasked(0x04) ? 0.070f : 0.0f;
+
+//        System.out.println("New voltage " + voltage);
+        byte audioByte = (byte)((voltage / 4.5) * 128);
+        System.out.println("New audio byte " + audioByte);
+        Arrays.fill(audioBuffer, audioByte);
+
+        if (audioOutputLine != null) {
+            audioOutputLine.flush();
+            audioOutputLine.write(audioBuffer, 0, Emulator.MIN_AUDIO_SAMPLES);
+        }
     }
 
     /**
@@ -46,7 +82,7 @@ public class PIA2a extends PIA
      */
     @Override
     public void setControlRegister(UnsignedByte newControlRegister) {
-        controlRegister = new UnsignedByte(newControlRegister.getShort() +
+        controlRegister = new UnsignedByte(newControlRegister.get() +
                         (controlRegister.isMasked(0x80) ? 0x80 : 0) +
                         (controlRegister.isMasked(0x40) ? 0x40 : 0));
 

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA2b.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA2b.java
@@ -8,12 +8,12 @@ import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
 
 public class PIA2b extends PIA
 {
-    protected UnsignedByte vdgOperatingMode;
+    protected UnsignedByte vdgMode;
     protected IOController io;
 
     public PIA2b(IOController newIO) {
         super();
-        vdgOperatingMode = new UnsignedByte();
+        vdgMode = new UnsignedByte();
         io = newIO;
     }
 
@@ -29,16 +29,19 @@ public class PIA2b extends PIA
     }
 
     /**
-     * In the Color Computer line of computers, PIA 1 side A is always configured for
-     * input, not for output. Writing to the data register does nothing.
+     * In the Color Computer line of computers, the PIA 2 side B is connected to
+     * the Video Display Generator. Writing to the data register will set the
+     * video mode. Bits 3-7 are connected to the VDG. The bits must be set for
+     * output based on the data direction register.
      *
      * @param newDataRegister the new value for the data register
      */
     @Override
     public void setDataRegister(UnsignedByte newDataRegister) {
-        vdgOperatingMode = newDataRegister.copy();
-//        vdgOperatingMode.and(~dataDirectionRegister.getShort());
-        io.updateVideoMode(vdgOperatingMode);
+        vdgMode = newDataRegister.copy();
+        vdgMode.and(dataDirectionRegister);
+        vdgMode.and(~0x7);
+        io.updateVideoMode(vdgMode);
         dataRegister = newDataRegister.copy();
     }
 
@@ -58,7 +61,7 @@ public class PIA2b extends PIA
         /* Bit 0 = FIRQ from cartridge ROM */
     }
 
-    public UnsignedByte getVDGOperatingMode() {
-        return vdgOperatingMode;
+    public UnsignedByte getVdgMode() {
+        return vdgMode;
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/components/PIA2b.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/PIA2b.java
@@ -50,7 +50,7 @@ public class PIA2b extends PIA
      */
     @Override
     public void setControlRegister(UnsignedByte newControlRegister) {
-        controlRegister = new UnsignedByte(newControlRegister.getShort() +
+        controlRegister = new UnsignedByte(newControlRegister.get() +
                         (controlRegister.isMasked(0x80) ? 0x80 : 0) +
                         (controlRegister.isMasked(0x40) ? 0x40 : 0));
         /* Bit 2 = Control whether Data Register or Data Direction Register active */

--- a/src/main/java/ca/craigthomas/yacoco3e/components/Screen.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/Screen.java
@@ -1,114 +1,102 @@
 /*
- * Copyright (C) 2017 Craig Thomas
+ * Copyright (C) 2017-2025 Craig Thomas
  * This project uses an MIT style license - see LICENSE for details.
  */
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.screen.*;
+import ca.craigthomas.yacoco3e.datatypes.screen.ScreenMode.Mode;
 
 import java.awt.image.BufferedImage;
 
 public class Screen
 {
-    // The current screen mode
     private ScreenMode screenMode;
-    // The IO controller for the computer
     private IOController io;
-    // Whether the resolution changed
     private boolean resolutionChanged;
-    // The current memory offset for video
     private int memoryOffset;
-    // The current scale factor
     private int scale;
-    // The current mode
-    private ScreenMode.Mode currentMode;
-    // The saved color set
     private int colorSet;
+    private ScreenMode.Mode currentMode;
 
-    public Screen(int scale) {
-        this.scale = scale;
-        resolutionChanged = false;
-        currentMode = ScreenMode.Mode.SG6;
-        colorSet = 0;
-        setMode(ScreenMode.Mode.SG4, colorSet);
+    public Screen(int newScale) {
+        scale = newScale;
+        setMode(Mode.SG4, 0);
     }
 
     /**
      * Sets the current video mode.
      *
      * @param mode the video mode to set
+     * @param newColorSet the new color set to use
      */
-    public void setMode(ScreenMode.Mode mode, int colorSet) {
-        if (currentMode.equals(mode) && colorSet == this.colorSet) {
+    public void setMode(ScreenMode.Mode mode, int newColorSet) {
+        if (currentMode == mode && colorSet == newColorSet) {
             return;
         }
 
-//        System.out.println("Set screen mode " + mode);
+        colorSet = newColorSet;
+        currentMode = mode;
+
         switch (mode) {
             case SG4:
-                this.screenMode = new SG4ScreenMode(scale);
+                screenMode = new SG4ScreenMode(scale);
                 break;
 
             case SG6:
-                this.screenMode = new SG6ScreenMode(scale, colorSet);
+                screenMode = new SG6ScreenMode(scale, colorSet);
                 break;
 
             case SG8:
-                this.screenMode = new SG8ScreenMode(scale);
+                screenMode = new SG8ScreenMode(scale);
                 break;
 
             case SG12:
-                this.screenMode = new SG12ScreenMode(scale);
+                screenMode = new SG12ScreenMode(scale);
                 break;
 
             case SG24:
-                this.screenMode = new SG24ScreenMode(scale);
+                screenMode = new SG24ScreenMode(scale);
                 break;
 
             case G1C:
-                this.screenMode = new G1CScreenMode(scale, colorSet);
+                screenMode = new G1CScreenMode(scale, colorSet);
                 break;
 
             case G1R:
-                this.screenMode = new G1RScreenMode(scale, colorSet);
+                screenMode = new G1RScreenMode(scale, colorSet);
                 break;
 
             case G2C:
-                this.screenMode = new G2CScreenMode(scale, colorSet);
+                screenMode = new G2CScreenMode(scale, colorSet);
                 break;
 
             case G2R:
-                this.screenMode = new G2RScreenMode(scale, colorSet);
+                screenMode = new G2RScreenMode(scale, colorSet);
                 break;
 
             case G3C:
-                this.screenMode = new G3CScreenMode(scale, colorSet);
+                screenMode = new G3CScreenMode(scale, colorSet);
                 break;
 
             case G3R:
-                this.screenMode = new G3RScreenMode(scale, colorSet);
+                screenMode = new G3RScreenMode(scale, colorSet);
                 break;
 
             case G6C:
-                this.screenMode = new G6CScreenMode(scale, colorSet);
+                screenMode = new G6CScreenMode(scale, colorSet);
                 break;
 
             case G6R:
-                this.screenMode = new G6RScreenMode(scale, colorSet);
+                screenMode = new G6RScreenMode(scale, colorSet);
                 break;
 
             default:
                 break;
         }
-        this.screenMode.setMemoryOffset(memoryOffset);
-        this.screenMode.setIOController(io);
-        this.colorSet = colorSet;
+        screenMode.setMemoryOffset(memoryOffset);
+        screenMode.setIOController(io);
         resolutionChanged = true;
-        currentMode = mode;
-    }
-
-    public ScreenMode.Mode getMode() {
-        return currentMode;
     }
 
     /**
@@ -117,7 +105,7 @@ public class Screen
      * @param ioController the IO controller associated with the screen
      */
     public void setIOController(IOController ioController) {
-        this.io = ioController;
+        io = ioController;
         screenMode.setIOController(ioController);
     }
 

--- a/src/main/java/ca/craigthomas/yacoco3e/components/VoidInstruction.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/VoidInstruction.java
@@ -176,7 +176,7 @@ public class VoidInstruction extends Instruction
     public static void exchangeRegister(IOController io, UnsignedByte memoryByte, UnsignedWord address) {
         UnsignedWord temp = new UnsignedWord();
         UnsignedByte tempByte = new UnsignedByte();
-        switch (memoryByte.getShort()) {
+        switch (memoryByte.get()) {
             /* A:B <-> X */
             case 0x01:
             case 0x10:
@@ -368,7 +368,7 @@ public class VoidInstruction extends Instruction
      * to and from is encoded by the post byte read.
      */
     public static void transferRegister(IOController io, UnsignedByte memoryByte, UnsignedWord address) {
-        switch (memoryByte.getShort()) {
+        switch (memoryByte.get()) {
             /* A:B -> X */
             case 0x01:
                 io.regs.x.set(io.regs.getD());

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedByte.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedByte.java
@@ -37,7 +37,7 @@ public class UnsignedByte
      *
      * @return the short value of the byte
      */
-    public short getShort() {
+    public short get() {
         return (short) (value & 0xFF);
     }
 
@@ -48,8 +48,8 @@ public class UnsignedByte
      *
      * @return the signed short value of the byte
      */
-    public short getSignedShort() {
-        return (isMasked(0x80)) ? (short) -(twosCompliment().getShort()) : getShort();
+    public short getSigned() {
+        return (value & 0x80) > 0 ? (short) -((~value + 1) & 0xFF) : value;
     }
 
     /**
@@ -91,16 +91,22 @@ public class UnsignedByte
         value = (short) ((value + (x & 0xFF)) & 0xFF);
     }
 
+    /**
+     * Shifts the bits right by one place.
+     */
     public void shiftRight() {
         value = (short) ((value >> 1) & 0xFF);
     }
 
+    /**
+     * Shits the bits left by one place.
+     */
     public void shiftLeft() {
         value = (short) ((value << 1) & 0xFF);
     }
 
     public void compliment() {
-        value = (short) (~value & 0xFF);
+        value = (short) (value ^ 0xFF);
     }
 
     /**
@@ -113,7 +119,7 @@ public class UnsignedByte
     }
 
     public void and(UnsignedByte mask) {
-        and(mask.getShort());
+        and(mask.get());
     }
 
     /**
@@ -126,7 +132,7 @@ public class UnsignedByte
     }
 
     public void or(UnsignedByte mask) {
-        or(mask.getShort());
+        or(mask.get());
     }
 
     /**
@@ -172,7 +178,7 @@ public class UnsignedByte
      * @param x the new byte value to set
      */
     public void set(UnsignedByte x) {
-        value = x.getShort();
+        value = x.get();
     }
 
     public boolean equalsInt(int value) {
@@ -190,7 +196,7 @@ public class UnsignedByte
 
         UnsignedByte that = (UnsignedByte) o;
 
-        return this.getShort() == that.getShort();
+        return this.get() == that.get();
     }
 
     @Override

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedWord.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/UnsignedWord.java
@@ -48,8 +48,7 @@ public class UnsignedWord
      * @param high the setHigh byte for the word
      */
     public void setHigh(UnsignedByte high) {
-        value &= 0x00FF;
-        value += (high.getShort() << 8);
+        value = (high.get() << 8) + (value & 0x00FF);
     }
 
     /**
@@ -67,8 +66,7 @@ public class UnsignedWord
      * @param low the low byte for the word
      */
     public void setLow(UnsignedByte low) {
-        value &= 0xFF00;
-        value += low.getShort();
+        value = (value & 0xFF00) + low.get();
     }
 
     /**
@@ -86,18 +84,7 @@ public class UnsignedWord
      * @param value the additional value to add
      */
     public void add(int value) {
-        this.value += value;
-        and(0xFFFF);
-    }
-
-    /**
-     * Returns a new UnsignedWord that is the twos compliment
-     * value of the current Word.
-     *
-     * @return a new UnsignedWord with the twos compliment value
-     */
-    public UnsignedWord twosCompliment() {
-        return new UnsignedWord((~value + 1));
+        this.value = (this.value + value) & 0xFFFF;
     }
 
     /**
@@ -142,7 +129,7 @@ public class UnsignedWord
      * @return True if the signed value of the byte would be negative
      */
     public boolean isNegative() {
-        return isMasked(0x8000);
+        return (value & 0x8000) > 0;
     }
 
     /**
@@ -153,7 +140,7 @@ public class UnsignedWord
      * @return True if applying the mask would result in a non-zero value
      */
     public boolean isMasked(int mask) {
-        return (getInt() & mask) == mask;
+        return (value & mask) == mask;
     }
 
     /**
@@ -171,7 +158,7 @@ public class UnsignedWord
      * @param value the value to set
      */
     public void set(UnsignedWord value) {
-        this.value = value.getInt();
+        this.value = value.get();
     }
 
     /**
@@ -179,7 +166,7 @@ public class UnsignedWord
      *
      * @return the integer representation of the word
      */
-    public int getInt() {
+    public int get() {
         return value;
     }
 
@@ -190,7 +177,7 @@ public class UnsignedWord
      * @return the signed integer representation of the word
      */
     public int getSignedInt() {
-        return (isNegative()) ? -(twosCompliment().getInt()) : value;
+        return ((value & 0x8000) > 0) ? -((~value + 1) & 0xFFFF) : value;
     }
 
     /**
@@ -209,12 +196,12 @@ public class UnsignedWord
 
         UnsignedWord that = (UnsignedWord) o;
 
-        return this.getInt() == that.getInt();
+        return this.get() == that.get();
     }
 
     @Override
     public int hashCode() {
-        return getInt();
+        return get();
     }
 
     @Override

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G1CScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G1CScreenMode.java
@@ -80,19 +80,19 @@ public class G1CScreenMode extends ScreenMode
         int y = 24 + (row * BLOCK_HEIGHT);
 
         /* Pixel 1 */
-        int color = (value.getShort() & 0xC0) >> 6;
+        int color = (value.get() & 0xC0) >> 6;
         drawBlock(x, y, color);
 
         /* Pixel 2 */
-        color = (value.getShort() & 0x30) >> 4;
+        color = (value.get() & 0x30) >> 4;
         drawBlock(x + BLOCK_WIDTH, y, color);
 
         /* Pixel 3 */
-        color = (value.getShort() & 0xC) >> 2;
+        color = (value.get() & 0xC) >> 2;
         drawBlock(x + (BLOCK_WIDTH * 2), y, color);
 
         /* Pixel 4 */
-        color = (value.getShort() & 0x3);
+        color = (value.get() & 0x3);
         drawBlock(x + (BLOCK_WIDTH * 3), y, color);
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G1RScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G1RScreenMode.java
@@ -76,35 +76,35 @@ public class G1RScreenMode extends ScreenMode
         int y = 24 + (row * BLOCK_HEIGHT);
 
         /* Pixel 1 */
-        int color = (value.getShort() & 0x80) >> 7;
+        int color = (value.get() & 0x80) >> 7;
         drawBlock(x, y, color);
 
         /* Pixel 2 */
-        color = (value.getShort() & 0x40) >> 6;
+        color = (value.get() & 0x40) >> 6;
         drawBlock(x + BLOCK_WIDTH, y, color);
 
         /* Pixel 3 */
-        color = (value.getShort() & 0x20) >> 5;
+        color = (value.get() & 0x20) >> 5;
         drawBlock(x + (BLOCK_WIDTH * 2), y, color);
 
         /* Pixel 4 */
-        color = (value.getShort() & 0x10) >> 4;
+        color = (value.get() & 0x10) >> 4;
         drawBlock(x + (BLOCK_WIDTH * 3), y, color);
 
         /* Pixel 5 */
-        color = (value.getShort() & 0x8) >> 3;
+        color = (value.get() & 0x8) >> 3;
         drawBlock(x + (BLOCK_WIDTH * 4), y, color);
 
         /* Pixel 6 */
-        color = (value.getShort() & 0x4) >> 2;
+        color = (value.get() & 0x4) >> 2;
         drawBlock(x + (BLOCK_WIDTH * 5), y, color);
 
         /* Pixel 7 */
-        color = (value.getShort() & 0x2) >> 1;
+        color = (value.get() & 0x2) >> 1;
         drawBlock(x + (BLOCK_WIDTH * 6), y, color);
 
         /* Pixel 8 */
-        color = (value.getShort() & 0x1);
+        color = (value.get() & 0x1);
         drawBlock(x + (BLOCK_WIDTH * 7), y, color);
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G2CScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G2CScreenMode.java
@@ -79,19 +79,19 @@ public class G2CScreenMode extends ScreenMode
         int y = 24 + (row * BLOCK_HEIGHT);
 
         /* Pixel 1 */
-        int color = (value.getShort() & 0xC0) >> 6;
+        int color = (value.get() & 0xC0) >> 6;
         drawBlock(x, y, color);
 
         /* Pixel 2 */
-        color = (value.getShort() & 0x30) >> 4;
+        color = (value.get() & 0x30) >> 4;
         drawBlock(x + BLOCK_WIDTH, y, color);
 
         /* Pixel 3 */
-        color = (value.getShort() & 0xC) >> 2;
+        color = (value.get() & 0xC) >> 2;
         drawBlock(x + (BLOCK_WIDTH * 2), y, color);
 
         /* Pixel 4 */
-        color = (value.getShort() & 0x3);
+        color = (value.get() & 0x3);
         drawBlock(x + (BLOCK_WIDTH * 3), y, color);
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G2RScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G2RScreenMode.java
@@ -76,35 +76,35 @@ public class G2RScreenMode extends ScreenMode
         int y = 24 + (row * BLOCK_HEIGHT);
 
         /* Pixel 1 */
-        int color = (value.getShort() & 0x80) >> 7;
+        int color = (value.get() & 0x80) >> 7;
         drawBlock(x, y, color);
 
         /* Pixel 2 */
-        color = (value.getShort() & 0x40) >> 6;
+        color = (value.get() & 0x40) >> 6;
         drawBlock(x + BLOCK_WIDTH, y, color);
 
         /* Pixel 3 */
-        color = (value.getShort() & 0x20) >> 5;
+        color = (value.get() & 0x20) >> 5;
         drawBlock(x + (2 * BLOCK_WIDTH), y, color);
 
         /* Pixel 4 */
-        color = (value.getShort() & 0x10) >> 4;
+        color = (value.get() & 0x10) >> 4;
         drawBlock(x + (3 * BLOCK_WIDTH), y, color);
 
         /* Pixel 5 */
-        color = (value.getShort() & 0x8) >> 3;
+        color = (value.get() & 0x8) >> 3;
         drawBlock(x + (4 * BLOCK_WIDTH), y, color);
 
         /* Pixel 6 */
-        color = (value.getShort() & 0x4) >> 2;
+        color = (value.get() & 0x4) >> 2;
         drawBlock(x + (5 * BLOCK_WIDTH), y, color);
 
         /* Pixel 7 */
-        color = (value.getShort() & 0x2) >> 1;
+        color = (value.get() & 0x2) >> 1;
         drawBlock(x + (6 * BLOCK_WIDTH), y, color);
 
         /* Pixel 8 */
-        color = (value.getShort() & 0x1);
+        color = (value.get() & 0x1);
         drawBlock(x + (7 * BLOCK_WIDTH), y, color);
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G3CScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G3CScreenMode.java
@@ -80,19 +80,19 @@ public class G3CScreenMode extends ScreenMode
         int y = 24 + (row * BLOCK_HEIGHT);
 
         /* Pixel 1 */
-        int color = (value.getShort() & 0xC0) >> 6;
+        int color = (value.get() & 0xC0) >> 6;
         drawBlock(x, y, color);
 
         /* Pixel 2 */
-        color = (value.getShort() & 0x30) >> 4;
+        color = (value.get() & 0x30) >> 4;
         drawBlock(x + BLOCK_WIDTH, y, color);
 
         /* Pixel 3 */
-        color = (value.getShort() & 0xC) >> 2;
+        color = (value.get() & 0xC) >> 2;
         drawBlock(x + (BLOCK_WIDTH * 2), y, color);
 
         /* Pixel 4 */
-        color = (value.getShort() & 0x3);
+        color = (value.get() & 0x3);
         drawBlock(x + (BLOCK_WIDTH * 3), y, color);
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G3RScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G3RScreenMode.java
@@ -76,35 +76,35 @@ public class G3RScreenMode extends ScreenMode
         int y = 24 + (row * BLOCK_HEIGHT);
 
         /* Pixel 1 */
-        int color = (value.getShort() & 0x80) >> 7;
+        int color = (value.get() & 0x80) >> 7;
         drawBlock(x, y, color);
 
         /* Pixel 2 */
-        color = (value.getShort() & 0x40) >> 6;
+        color = (value.get() & 0x40) >> 6;
         drawBlock(x + BLOCK_WIDTH, y, color);
 
         /* Pixel 3 */
-        color = (value.getShort() & 0x20) >> 5;
+        color = (value.get() & 0x20) >> 5;
         drawBlock(x + (2 * BLOCK_WIDTH), y, color);
 
         /* Pixel 4 */
-        color = (value.getShort() & 0x10) >> 4;
+        color = (value.get() & 0x10) >> 4;
         drawBlock(x + (3 * BLOCK_WIDTH), y, color);
 
         /* Pixel 5 */
-        color = (value.getShort() & 0x8) >> 3;
+        color = (value.get() & 0x8) >> 3;
         drawBlock(x + (4 * BLOCK_WIDTH), y, color);
 
         /* Pixel 6 */
-        color = (value.getShort() & 0x4) >> 2;
+        color = (value.get() & 0x4) >> 2;
         drawBlock(x + (5 * BLOCK_WIDTH), y, color);
 
         /* Pixel 7 */
-        color = (value.getShort() & 0x2) >> 1;
+        color = (value.get() & 0x2) >> 1;
         drawBlock(x + (6 * BLOCK_WIDTH), y, color);
 
         /* Pixel 8 */
-        color = (value.getShort() & 0x1);
+        color = (value.get() & 0x1);
         drawBlock(x + (7 * BLOCK_WIDTH), y, color);
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G6CScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G6CScreenMode.java
@@ -80,19 +80,19 @@ public class G6CScreenMode extends ScreenMode
         int y = 24 + (row * BLOCK_HEIGHT);
 
         /* Pixel 1 */
-        int color = (value.getShort() & 0xC0) >> 6;
+        int color = (value.get() & 0xC0) >> 6;
         drawBlock(x, y, color);
 
         /* Pixel 2 */
-        color = (value.getShort() & 0x30) >> 4;
+        color = (value.get() & 0x30) >> 4;
         drawBlock(x + BLOCK_WIDTH, y, color);
 
         /* Pixel 3 */
-        color = (value.getShort() & 0xC) >> 2;
+        color = (value.get() & 0xC) >> 2;
         drawBlock(x + (BLOCK_WIDTH * 2), y, color);
 
         /* Pixel 4 */
-        color = (value.getShort() & 0x3);
+        color = (value.get() & 0x3);
         drawBlock(x + (BLOCK_WIDTH * 3), y, color);
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G6RScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/G6RScreenMode.java
@@ -82,19 +82,19 @@ public class G6RScreenMode extends ScreenMode
         int y = 24 + (row * BLOCK_HEIGHT);
 
         /* Pixel 1 */
-        int color = (value.getShort() & 0xC0) >> 6;
+        int color = (value.get() & 0xC0) >> 6;
         drawBlock(x, y, color);
 
         /* Pixel 2 */
-        color = (value.getShort() & 0x30) >> 4;
+        color = (value.get() & 0x30) >> 4;
         drawBlock(x + BLOCK_WIDTH, y, color);
 
         /* Pixel 3 */
-        color = (value.getShort() & 0xC) >> 2;
+        color = (value.get() & 0xC) >> 2;
         drawBlock(x + (BLOCK_WIDTH * 2), y, color);
 
         /* Pixel 4 */
-        color = (value.getShort() & 0x3);
+        color = (value.get() & 0x3);
         drawBlock(x + (BLOCK_WIDTH * 3), y, color);
     }
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG12ScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG12ScreenMode.java
@@ -112,7 +112,7 @@ public class SG12ScreenMode extends ScreenMode
         int y = 24 + (row * BLOCK_HEIGHT);
 
         /* Background colors */
-        int color = (value.getShort() & 0x70) >> 4;
+        int color = (value.get() & 0x70) >> 4;
         if (!value.isMasked(0x80)) {
             color = BLACK;
         }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG24ScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG24ScreenMode.java
@@ -113,7 +113,7 @@ public class SG24ScreenMode extends ScreenMode
 
         /* Background colors */
         int back = BLACK;
-        int color = (value.getShort() & 0x70) >> 4;
+        int color = (value.get() & 0x70) >> 4;
 
         /* Subcell B */
         int mask = rowMod == 0 || rowMod == 1 || rowMod == 2 || rowMod == 3 || rowMod == 4 || rowMod == 5 || rowMod == 6 ? 0x8 : 0x2;

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG4ScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG4ScreenMode.java
@@ -129,7 +129,7 @@ public class SG4ScreenMode extends ScreenMode
         int back = backColor;
 
         if (value.isNegative()) {
-            int color = (value.getShort() & 0x70) >> 4;
+            int color = (value.get() & 0x70) >> 4;
 
             /* Upper Left Bit */
             int on = value.isMasked(0x8) ? 1 : 0;
@@ -147,10 +147,10 @@ public class SG4ScreenMode extends ScreenMode
             on = value.isMasked(0x1) ? 1 : 0;
             drawSG4Block(x + BLOCK_WIDTH, y + BLOCK_HEIGHT, on == 1 ? color : back);
         } else {
-            int intValue = value.getShort() & 0x3F;
+            int intValue = value.get() & 0x3F;
             int character = intValue > SG4_CHARACTERS.length ?
                     intValue - SG4_CHARACTERS.length : intValue;
-            boolean inverse = value.getShort() < SG4_CHARACTERS.length;
+            boolean inverse = value.get() < SG4_CHARACTERS.length;
 
             if (!inverse) {
                 fore = backColor;

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG6ScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG6ScreenMode.java
@@ -120,7 +120,7 @@ public class SG6ScreenMode extends ScreenMode
         /* Background colors */
         int back = BLACK;
 
-        int color = (value.getShort() & 0xC0) >> 6;
+        int color = (value.get() & 0xC0) >> 6;
         if (colorSet == 1) {
             color = color + 4;
         }

--- a/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG8ScreenMode.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/datatypes/screen/SG8ScreenMode.java
@@ -113,7 +113,7 @@ public class SG8ScreenMode extends ScreenMode
 
         /* Background colors */
         int back = BLACK;
-        int color = (value.getShort() & 0x70) >> 4;
+        int color = (value.get() & 0x70) >> 4;
 
         /* Subcell B */
         int mask = rowMod == 0 || rowMod == 1 ? 0x8 : 0x2;

--- a/src/main/java/ca/craigthomas/yacoco3e/runner/Arguments.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/runner/Arguments.java
@@ -31,4 +31,7 @@ public class Arguments
 
     @Parameter(names="--config", description="path to config file")
     public String configFile;
+
+    @Parameter(names="--enabledac", description="enable digital analog converter")
+    public Boolean useDAC = false;
 }

--- a/src/main/java/ca/craigthomas/yacoco3e/runner/Runner.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/runner/Runner.java
@@ -32,6 +32,7 @@ public class Runner
                 .setCassetteFile(arguments.cassetteFile)
                 .setCartridgeROM(arguments.cartridgeROM)
                 .setConfigFile(arguments.configFile)
+                .setDAC(arguments.useDAC)
                 .build();
         emulator.start();
     }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/BranchInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/BranchInstructionTest.java
@@ -23,7 +23,7 @@ public class BranchInstructionTest {
         Cassette cassette = new Cassette();
         memory = new Memory();
         regs = new RegisterSet();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
         cpu = new CPU(io);
     }
 
@@ -36,21 +36,21 @@ public class BranchInstructionTest {
     public void testBranchAlways() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x201F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
     public void testBranchAlwaysNegativeOffset() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x20FE);
         cpu.executeInstruction();
-        assertEquals(0x0000, regs.pc.getInt());
+        assertEquals(0x0000, regs.pc.get());
     }
 
     @Test
     public void testBranchAlwaysNegativeOffsetLoopsAround() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x20FD);
         cpu.executeInstruction();
-        assertEquals(0xFFFF, regs.pc.getInt());
+        assertEquals(0xFFFF, regs.pc.get());
     }
 
     @Test
@@ -58,7 +58,7 @@ public class BranchInstructionTest {
         regs.pc.set(0x0009);
         io.writeWord(0x0009, 0x207F);
         cpu.executeInstruction();
-        assertEquals(0x008A, regs.pc.getInt());
+        assertEquals(0x008A, regs.pc.get());
     }
 
     @Test
@@ -66,7 +66,7 @@ public class BranchInstructionTest {
         regs.pc.set(0x0056);
         io.writeWord(0x0056, 0x20AA);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class BranchInstructionTest {
     public void testBranchNever() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x21FF);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -86,8 +86,8 @@ public class BranchInstructionTest {
         regs.s.set(0x0200);
         regs.pc.set(0xBEEF);
         assertTrue(BranchInstruction.branchToSubroutine(io));
-        assertEquals(0xEF, io.readByte(new UnsignedWord(0x01FF)).getShort());
-        assertEquals(0xBE, io.readByte(new UnsignedWord(0x01FE)).getShort());
+        assertEquals(0xEF, io.readByte(new UnsignedWord(0x01FF)).get());
+        assertEquals(0xBE, io.readByte(new UnsignedWord(0x01FE)).get());
     }
 
     @Test
@@ -96,9 +96,9 @@ public class BranchInstructionTest {
         regs.pc.set(0x1021);
         io.writeWord(0x1021, 0x8D1F);
         cpu.executeInstruction();
-        assertEquals(0x1042, regs.pc.getInt());
-        assertEquals(0x23, memory.readByte(0x2FFF).getShort());
-        assertEquals(0x10, memory.readByte(0x2FFE).getShort());
+        assertEquals(0x1042, regs.pc.get());
+        assertEquals(0x23, memory.readByte(0x2FFF).get());
+        assertEquals(0x10, memory.readByte(0x2FFE).get());
     }
 
     @Test
@@ -107,9 +107,9 @@ public class BranchInstructionTest {
         regs.pc.set(0x1021);
         io.writeWord(0x1021, 0x8DDD);
         cpu.executeInstruction();
-        assertEquals(0x1000, regs.pc.getInt());
-        assertEquals(0x23, memory.readByte(0x2FFF).getShort());
-        assertEquals(0x10, memory.readByte(0x2FFE).getShort());
+        assertEquals(0x1000, regs.pc.get());
+        assertEquals(0x23, memory.readByte(0x2FFF).get());
+        assertEquals(0x10, memory.readByte(0x2FFE).get());
     }
 
     @Test
@@ -133,7 +133,7 @@ public class BranchInstructionTest {
     public void testBranchOnHighCalledCorrect() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x221F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -141,7 +141,7 @@ public class BranchInstructionTest {
         io.regs.cc.or(CC_C);
         io.writeWord(0x0000, 0x221F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -149,7 +149,7 @@ public class BranchInstructionTest {
         io.regs.cc.or(CC_Z);
         io.writeWord(0x0000, 0x221F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -180,7 +180,7 @@ public class BranchInstructionTest {
     public void testBranchOnLowerNotCalledWhenZeroCarryClear() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x231F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -189,7 +189,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_C);
         io.writeWord(0x0000, 0x231F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -198,7 +198,7 @@ public class BranchInstructionTest {
         io.regs.cc.or(CC_C);
         io.writeWord(0x0000, 0x231F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -206,7 +206,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_Z);
         io.writeWord(0x0000, 0x231F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -214,7 +214,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_C);
         io.writeWord(0x0000, 0x231F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -232,7 +232,7 @@ public class BranchInstructionTest {
     public void testBranchOnCarryClearCalledCorrect() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x241F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -240,7 +240,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_C);
         io.writeWord(0x0000, 0x241F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -259,14 +259,14 @@ public class BranchInstructionTest {
         regs.cc.or(CC_C);
         io.writeWord(0x0000, 0x251F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
     public void testBranchOnCarrySetDoesNotBranchIfCarryClear() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x251F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -284,7 +284,7 @@ public class BranchInstructionTest {
     public void testBranchOnNotEqualCalledCorrect() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x261F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -292,7 +292,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_Z);
         io.writeWord(0x0000, 0x261F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -311,14 +311,14 @@ public class BranchInstructionTest {
         regs.cc.or(CC_Z);
         io.writeWord(0x0000, 0x271F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
     public void testBranchOnEqualDoesNotBranchIfZeroClear() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x271F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -336,7 +336,7 @@ public class BranchInstructionTest {
     public void testBranchOnOverflowClearCalledCorrect() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x281F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -344,7 +344,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x281F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -363,14 +363,14 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x291F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
     public void testBranchOnOverflowSetDoesNotBranchIfOverflowClear() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x291F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -388,7 +388,7 @@ public class BranchInstructionTest {
     public void testBranchOnPlusCalledCorrect() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x2A1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -396,7 +396,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2A1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -415,14 +415,14 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2B1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
     public void testBranchOnMinusDoesNotBranchIfNegativeClear() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x2B1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -453,7 +453,7 @@ public class BranchInstructionTest {
     public void testBranchOnGreaterThanEqualZeroCalledCorrect() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x2C1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -462,7 +462,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x2C1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -470,7 +470,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2C1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -478,7 +478,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x2C1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -509,7 +509,7 @@ public class BranchInstructionTest {
     public void testBranchOnLessThanZeroNotCalledIfNegativeClearOverflowClear() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x2D1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -518,7 +518,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x2D1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -526,7 +526,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2D1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -534,7 +534,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x2D1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -594,7 +594,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_Z);
         io.writeWord(0x0000, 0x2E1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -604,7 +604,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2E1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -613,7 +613,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2E1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -622,7 +622,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x2E1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -630,7 +630,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x2E1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -638,14 +638,14 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2E1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
     public void testBranchOnGreaterThanZeroCalledIfZeroOverflowNegativeClear() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x2E1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -654,7 +654,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2E1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -714,7 +714,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_Z);
         io.writeWord(0x0000, 0x2F1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -724,7 +724,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x2F1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -733,7 +733,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2F1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -743,7 +743,7 @@ public class BranchInstructionTest {
         io.writeWord(0x0000, 0x2F1F);
         io.writeWord(0x0000, 0x2F1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -751,7 +751,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x2F1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
@@ -759,14 +759,14 @@ public class BranchInstructionTest {
         regs.cc.or(CC_N);
         io.writeWord(0x0000, 0x2F1F);
         cpu.executeInstruction();
-        assertEquals(0x0021, regs.pc.getInt());
+        assertEquals(0x0021, regs.pc.get());
     }
 
     @Test
     public void testBranchOnLessThanZeroNotCalledIfZeroNegativeOverflowClear() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x2F1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -775,7 +775,7 @@ public class BranchInstructionTest {
         regs.cc.or(CC_V);
         io.writeWord(0x0000, 0x2F1F);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
 }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/BranchInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/BranchInstructionTest.java
@@ -5,6 +5,7 @@
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,8 +24,13 @@ public class BranchInstructionTest {
         Cassette cassette = new Cassette();
         memory = new Memory();
         regs = new RegisterSet();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, false);
         cpu = new CPU(io);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/ByteInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/ByteInstructionTest.java
@@ -8,6 +8,7 @@ import static ca.craigthomas.yacoco3e.datatypes.RegisterSet.*;
 import static org.junit.Assert.*;
 
 import ca.craigthomas.yacoco3e.datatypes.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,10 +23,15 @@ public class ByteInstructionTest {
         Screen screen = new Screen(1);
         Cassette cassette = new Cassette();
         regs = new RegisterSet();
-        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, null);
+        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, false);
         cpu = new CPU(io);
         extendedAddress = 0xC0A0;
         io.regs.pc.set(0);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/ByteInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/ByteInstructionTest.java
@@ -4,7 +4,6 @@
  */
 package ca.craigthomas.yacoco3e.components;
 
-import static ca.craigthomas.yacoco3e.datatypes.AddressingMode.*;
 import static ca.craigthomas.yacoco3e.datatypes.RegisterSet.*;
 import static org.junit.Assert.*;
 
@@ -23,7 +22,7 @@ public class ByteInstructionTest {
         Screen screen = new Screen(1);
         Cassette cassette = new Cassette();
         regs = new RegisterSet();
-        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette);
+        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, null);
         cpu = new CPU(io);
         extendedAddress = 0xC0A0;
         io.regs.pc.set(0);
@@ -33,7 +32,7 @@ public class ByteInstructionTest {
     public void testNegateCorrect() {
         io.writeByte(0xCAFE, 0xFC);
         ByteInstruction.negate(io, new UnsignedByte(0xFC), new UnsignedWord(0xCAFE));
-        assertEquals(0x04, io.readByte(0xCAFE).getShort());
+        assertEquals(0x04, io.readByte(0xCAFE).get());
         assertTrue(regs.cc.isMasked(CC_C));
         assertFalse(regs.cc.isMasked(CC_V));
         assertFalse(regs.cc.isMasked(CC_N));
@@ -44,19 +43,19 @@ public class ByteInstructionTest {
     public void testNegateAllOnes() {
         io.writeByte(0xCAFE, 0xFF);
         ByteInstruction.negate(io, new UnsignedByte(0xFF), new UnsignedWord(0xCAFE));
-        assertEquals(1, io.readByte(0xCAFE).getShort());
+        assertEquals(1, io.readByte(0xCAFE).get());
     }
 
     @Test
     public void testNegateOne() {
         io.writeByte(0xCAFE, 0x1);
         ByteInstruction.negate(io, new UnsignedByte(1), new UnsignedWord(0xCAFE));
-        assertEquals(0xFF, io.readByte(0xCAFE).getShort());
+        assertEquals(0xFF, io.readByte(0xCAFE).get());
     }
 
     @Test
     public void testNegateSetsOverflowFlag() {
-        ByteInstruction.negate(io, new UnsignedByte(1), new UnsignedWord(0xCAFE));
+        ByteInstruction.negate(io, new UnsignedByte(0x80), new UnsignedWord(0xCAFE));
         assertTrue(regs.cc.isMasked(CC_V));
     }
 
@@ -70,7 +69,7 @@ public class ByteInstructionTest {
     public void testNegateEdgeCase() {
         io.writeByte(0xCAFE, 0x80);
         ByteInstruction.negate(io, new UnsignedByte(0x80), new UnsignedWord(0xCAFE));
-        assertEquals(0x80, io.readByte(0xCAFE).getShort());
+        assertEquals(0x80, io.readByte(0xCAFE).get());
         assertTrue(regs.cc.isMasked(CC_N));
         assertTrue(regs.cc.isMasked(CC_V));
         assertTrue(regs.cc.isMasked(CC_C));
@@ -80,7 +79,7 @@ public class ByteInstructionTest {
     public void testNegateEdgeCase1() {
         io.writeByte(0xCAFE, 0x0);
         ByteInstruction.negate(io, new UnsignedByte(0x0), new UnsignedWord(0xCAFE));
-        assertEquals(0, io.readByte(0xCAFE).getShort());
+        assertEquals(0, io.readByte(0xCAFE).get());
         assertFalse(regs.cc.isMasked(CC_N));
         assertFalse(regs.cc.isMasked(CC_V));
         assertFalse(regs.cc.isMasked(CC_C));
@@ -125,7 +124,7 @@ public class ByteInstructionTest {
     public void testComplimentWorksCorrectly() {
         io.writeByte(0xCAFE, 0xE6);
         ByteInstruction.compliment(io, new UnsignedByte(0xE6), new UnsignedWord(0xCAFE));
-        assertEquals(0x19, io.readByte(0xCAFE).getShort());
+        assertEquals(0x19, io.readByte(0xCAFE).get());
         assertTrue(regs.cc.isMasked(CC_C));
         assertFalse(regs.cc.isMasked(CC_N));
         assertFalse(regs.cc.isMasked(CC_V));
@@ -136,14 +135,14 @@ public class ByteInstructionTest {
     public void testComplementAllOnes() {
         io.writeByte(0xCAFE, 0xFF);
         ByteInstruction.compliment(io, new UnsignedByte(0xFF), new UnsignedWord(0xCAFE));
-        assertEquals(0, io.readByte(0xCAFE).getShort());
+        assertEquals(0, io.readByte(0xCAFE).get());
     }
 
     @Test
     public void testComplementOne() {
         io.writeByte(0xCAFE, 1);
         ByteInstruction.compliment(io, new UnsignedByte(0x01), new UnsignedWord(0xCAFE));
-        assertEquals(0xFE, io.readByte(0xCAFE).getShort());
+        assertEquals(0xFE, io.readByte(0xCAFE).get());
     }
 
     @Test
@@ -168,7 +167,7 @@ public class ByteInstructionTest {
     public void testComplementSetsZeroFlagCorrect() {
         io.writeByte(0xCAFE, 0xFF);
         ByteInstruction.compliment(io, new UnsignedByte(0xFF), new UnsignedWord(0xCAFE));
-        assertEquals(0, io.readByte(0xCAFE).getShort());
+        assertEquals(0, io.readByte(0xCAFE).get());
         assertTrue(regs.cc.isMasked(CC_Z));
     }
 
@@ -207,7 +206,7 @@ public class ByteInstructionTest {
     public void testLogicalShiftRightCorrect() {
         io.writeByte(0xCAFE, 0x9E);
         ByteInstruction.logicalShiftRight(io, new UnsignedByte(0x9E), new UnsignedWord(0xCAFE));
-        assertEquals(0x4F, io.readByte(0xCAFE).getShort());
+        assertEquals(0x4F, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_C));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertFalse(io.regs.cc.isMasked(CC_Z));
@@ -217,7 +216,7 @@ public class ByteInstructionTest {
     public void testLogicalShiftRightMovesOneBitCorrect() {
         io.writeByte(0xCAFE, 0x02);
         ByteInstruction.logicalShiftRight(io, new UnsignedByte(0x2), new UnsignedWord(0xCAFE));
-        assertEquals(1, io.readByte(0xCAFE).getShort());
+        assertEquals(1, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_C));
     }
 
@@ -225,7 +224,7 @@ public class ByteInstructionTest {
     public void testLogicalShiftRightMovesOneBitToZero() {
         io.writeByte(0xCAFE, 0x01);
         ByteInstruction.logicalShiftRight(io, new UnsignedByte(0x1), new UnsignedWord(0xCAFE));
-        assertEquals(0, io.readByte(0xCAFE).getShort());
+        assertEquals(0, io.readByte(0xCAFE).get());
         assertTrue(io.regs.cc.isMasked(CC_C));
     }
 
@@ -233,7 +232,7 @@ public class ByteInstructionTest {
     public void testLogicalShiftRightSetsZeroBit() {
         io.writeByte(0xCAFE, 0x01);
         ByteInstruction.logicalShiftRight(io, new UnsignedByte(0x1), new UnsignedWord(0xCAFE));
-        assertEquals(0, io.readByte(0xCAFE).getShort());
+        assertEquals(0, io.readByte(0xCAFE).get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_C));
     }
@@ -269,7 +268,7 @@ public class ByteInstructionTest {
     public void testRotateRightMovesOneBitCorrect() {
         io.writeByte(0xCAFE, 0x02);
         ByteInstruction.rotateRight(io, new UnsignedByte(0x02), new UnsignedWord(0xCAFE));
-        assertEquals(1, io.readByte(0xCAFE).getShort());
+        assertEquals(1, io.readByte(0xCAFE).get());
         assertFalse(regs.cc.isMasked(CC_C));
     }
 
@@ -278,7 +277,7 @@ public class ByteInstructionTest {
         regs.cc.or(CC_C);
         io.writeByte(0xCAFE, 0x02);
         ByteInstruction.rotateRight(io, new UnsignedByte(0x02), new UnsignedWord(0xCAFE));
-        assertEquals(0x81, io.readByte(0xCAFE).getShort());
+        assertEquals(0x81, io.readByte(0xCAFE).get());
         assertFalse(regs.cc.isMasked(CC_C));
     }
 
@@ -286,7 +285,7 @@ public class ByteInstructionTest {
     public void testRotateRightMovesOneBitToZero() {
         io.writeByte(0xCAFE, 0x01);
         ByteInstruction.rotateRight(io, new UnsignedByte(0x01), new UnsignedWord(0xCAFE));
-        assertEquals(0, io.readByte(0xCAFE).getShort());
+        assertEquals(0, io.readByte(0xCAFE).get());
         assertTrue(regs.cc.isMasked(CC_C));
     }
 
@@ -294,7 +293,7 @@ public class ByteInstructionTest {
     public void testRotateRightSetsZeroBit() {
         io.writeByte(0xCAFE, 0x01);
         ByteInstruction.rotateRight(io, new UnsignedByte(0x01), new UnsignedWord(0xCAFE));
-        assertEquals(0, io.readByte(0xCAFE).getShort());
+        assertEquals(0, io.readByte(0xCAFE).get());
         assertTrue(regs.cc.isMasked(CC_Z));
         assertTrue(regs.cc.isMasked(CC_C));
     }
@@ -304,7 +303,7 @@ public class ByteInstructionTest {
         regs.cc.or(CC_C);
         io.writeByte(0xCAFE, 0x01);
         ByteInstruction.rotateRight(io, new UnsignedByte(0x01), new UnsignedWord(0xCAFE));
-        assertEquals(0x80, io.readByte(0xCAFE).getShort());
+        assertEquals(0x80, io.readByte(0xCAFE).get());
         assertFalse(regs.cc.isMasked(CC_Z));
         assertTrue(regs.cc.isMasked(CC_C));
         assertTrue(regs.cc.isMasked(CC_N));
@@ -341,7 +340,7 @@ public class ByteInstructionTest {
     public void testArithmeticShiftRightCorrect() {
         io.writeByte(0xCAFE, 0x85);
         ByteInstruction.arithmeticShiftRight(io, new UnsignedByte(0x85), new UnsignedWord(0xCAFE));
-        assertEquals(0xC2, io.readByte(0xCAFE).getShort());
+        assertEquals(0xC2, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_C));
@@ -351,7 +350,7 @@ public class ByteInstructionTest {
     public void testArithmeticShiftRightOneCorrect() {
         io.writeByte(0xCAFE, 0x1);
         ByteInstruction.arithmeticShiftRight(io, new UnsignedByte(0x1), new UnsignedWord(0xCAFE));
-        assertEquals(0, io.readByte(0xCAFE).getShort());
+        assertEquals(0, io.readByte(0xCAFE).get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_C));
@@ -361,7 +360,7 @@ public class ByteInstructionTest {
     public void testArithmeticShiftRightHighBitRetained() {
         io.writeByte(0xCAFE, 0x81);
         ByteInstruction.arithmeticShiftRight(io, new UnsignedByte(0x81), new UnsignedWord(0xCAFE));
-        assertEquals(0xC0, io.readByte(0xCAFE).getShort());
+        assertEquals(0xC0, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_C));
@@ -371,7 +370,7 @@ public class ByteInstructionTest {
     public void testArithmeticShiftRightHighBitRetainedCarryCleared() {
         io.writeByte(0xCAFE, 0x80);
         ByteInstruction.arithmeticShiftRight(io, new UnsignedByte(0x80), new UnsignedWord(0xCAFE));
-        assertEquals(0xC0, io.readByte(0xCAFE).getShort());
+        assertEquals(0xC0, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
         assertFalse(io.regs.cc.isMasked(CC_C));
@@ -408,7 +407,7 @@ public class ByteInstructionTest {
     public void testArithmeticShiftLeftCorrect() {
         io.writeByte(0xCAFE, 0x55);
         ByteInstruction.arithmeticShiftLeft(io, new UnsignedByte(0x55), new UnsignedWord(0xCAFE));
-        assertEquals(0xAA, io.readByte(0xCAFE).getShort());
+        assertEquals(0xAA, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_V));
         assertTrue(io.regs.cc.isMasked(CC_N));
@@ -446,7 +445,7 @@ public class ByteInstructionTest {
     public void testArithmeticShiftLeftCorrectSecondTest() {
         io.writeByte(0xCAFE, 0x8A);
         ByteInstruction.arithmeticShiftLeft(io, new UnsignedByte(0x8A), new UnsignedWord(0xCAFE));
-        assertEquals(0x14, io.readByte(0xCAFE).getShort());
+        assertEquals(0x14, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_N));
@@ -457,7 +456,7 @@ public class ByteInstructionTest {
     public void testArithmeticShiftLeftOneCorrect() {
         io.writeByte(0xCAFE, 0x1);
         ByteInstruction.arithmeticShiftLeft(io, new UnsignedByte(0x1), new UnsignedWord(0xCAFE));
-        assertEquals(0x2, io.readByte(0xCAFE).getShort());
+        assertEquals(0x2, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_N));
@@ -468,7 +467,7 @@ public class ByteInstructionTest {
     public void testArithmeticShiftLeftHighBitShiftedToCarry() {
         io.writeByte(0xCAFE, 0x81);
         ByteInstruction.arithmeticShiftLeft(io, new UnsignedByte(0x81), new UnsignedWord(0xCAFE));
-        assertEquals(0x2, io.readByte(0xCAFE).getShort());
+        assertEquals(0x2, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_N));
@@ -479,7 +478,7 @@ public class ByteInstructionTest {
     public void testArithmeticShiftLeftHighBitShiftedToCarryZeroRemainder() {
         io.writeByte(0xCAFE, 0x80);
         ByteInstruction.arithmeticShiftLeft(io, new UnsignedByte(0x80), new UnsignedWord(0xCAFE));
-        assertEquals(0x0, io.readByte(0xCAFE).getShort());
+        assertEquals(0x0, io.readByte(0xCAFE).get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_N));
@@ -490,7 +489,7 @@ public class ByteInstructionTest {
     public void testRotateLeftOneCorrect() {
         io.writeByte(0xCAFE, 0x1);
         ByteInstruction.rotateLeft(io, new UnsignedByte(0x1), new UnsignedWord(0xCAFE));
-        assertEquals(0x2, io.readByte(0xCAFE).getShort());
+        assertEquals(0x2, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_C));
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_N));
@@ -528,7 +527,7 @@ public class ByteInstructionTest {
     public void testRotateLeftSetsCarry() {
         io.writeByte(0xCAFE, 0x80);
         ByteInstruction.rotateLeft(io, new UnsignedByte(0x80), new UnsignedWord(0xCAFE));
-        assertEquals(0x0, io.readByte(0xCAFE).getShort());
+        assertEquals(0x0, io.readByte(0xCAFE).get());
         assertTrue(io.regs.cc.isMasked(CC_C));
         assertTrue(io.regs.cc.isMasked(CC_V));
         assertTrue(io.regs.cc.isMasked(CC_Z));
@@ -540,7 +539,7 @@ public class ByteInstructionTest {
         io.regs.cc.or(CC_C);
         io.writeByte(0xCAFE, 0x1);
         ByteInstruction.rotateLeft(io, new UnsignedByte(0x1), new UnsignedWord(0xCAFE));
-        assertEquals(0x3, io.readByte(0xCAFE).getShort());
+        assertEquals(0x3, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_C));
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_Z));
@@ -551,7 +550,7 @@ public class ByteInstructionTest {
     public void testRotateLeftClearsOverflow() {
         io.writeByte(0xCAFE, 0xC);
         ByteInstruction.rotateLeft(io, new UnsignedByte(0xC0), new UnsignedWord(0xCAFE));
-        assertEquals(0x80, io.readByte(0xCAFE).getShort());
+        assertEquals(0x80, io.readByte(0xCAFE).get());
         assertTrue(io.regs.cc.isMasked(CC_C));
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_Z));
@@ -562,7 +561,7 @@ public class ByteInstructionTest {
     public void testDecrementWorksCorrectly() {
         io.writeByte(0xCAFE, 0xC4);
         ByteInstruction.decrement(io, new UnsignedByte(0xC4), new UnsignedWord(0xCAFE));
-        assertEquals(0xC3, io.readByte(0xCAFE).getShort());
+        assertEquals(0xC3, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
@@ -599,7 +598,7 @@ public class ByteInstructionTest {
     public void testDecrementOneCorrect() {
         io.writeByte(0xCAFE, 0x1);
         ByteInstruction.decrement(io, new UnsignedByte(0x1), new UnsignedWord(0xCAFE));
-        assertEquals(0x0, io.readByte(0xCAFE).getShort());
+        assertEquals(0x0, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertTrue(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
@@ -609,7 +608,7 @@ public class ByteInstructionTest {
     public void testDecrementZeroCorrect() {
         io.writeByte(0xCAFE, 0x0);
         ByteInstruction.decrement(io, new UnsignedByte(0), new UnsignedWord(0xCAFE));
-        assertEquals(0xFF, io.readByte(0xCAFE).getShort());
+        assertEquals(0xFF, io.readByte(0xCAFE).get());
         assertTrue(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
@@ -619,7 +618,7 @@ public class ByteInstructionTest {
     public void testDecrementHighValueCorrect() {
         io.writeByte(0xCAFE, 0xFF);
         ByteInstruction.decrement(io, new UnsignedByte(0xFF), new UnsignedWord(0xCAFE));
-        assertEquals(0xFE, io.readByte(0xCAFE).getShort());
+        assertEquals(0xFE, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
@@ -629,7 +628,7 @@ public class ByteInstructionTest {
     public void testIncrementOneCorrect() {
         io.writeByte(0xCAFE, 0x1);
         ByteInstruction.increment(io, new UnsignedByte(0x1), new UnsignedWord(0xCAFE));
-        assertEquals(0x2, io.readByte(0xCAFE).getShort());
+        assertEquals(0x2, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
@@ -666,7 +665,7 @@ public class ByteInstructionTest {
     public void testIncrementSetsOverflow() {
         io.writeByte(0xCAFE, 0x7F);
         ByteInstruction.increment(io, new UnsignedByte(0x7F), new UnsignedWord(0xCAFE));
-        assertEquals(0x80, io.readByte(0xCAFE).getShort());
+        assertEquals(0x80, io.readByte(0xCAFE).get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_V));
         assertTrue(io.regs.cc.isMasked(CC_N));
@@ -676,7 +675,7 @@ public class ByteInstructionTest {
     public void testIncrementSetsZero() {
         io.writeByte(0xCAFE, 0xFF);
         ByteInstruction.increment(io, new UnsignedByte(0xFF), new UnsignedWord(0xCAFE));
-        assertEquals(0x0, io.readByte(0xCAFE).getShort());
+        assertEquals(0x0, io.readByte(0xCAFE).get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_N));
@@ -733,7 +732,7 @@ public class ByteInstructionTest {
     public void testClearWorksCorrect() {
         io.writeByte(0xCAFE, 0xFF);
         ByteInstruction.clear(io, new UnsignedByte(0x1), new UnsignedWord(0xCAFE));
-        assertEquals(0, io.readByte(0xCAFE).getShort());
+        assertEquals(0, io.readByte(0xCAFE).get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
     }
 

--- a/src/test/java/ca/craigthomas/yacoco3e/components/ByteRegisterInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/ByteRegisterInstructionTest.java
@@ -5,6 +5,7 @@
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,9 +24,14 @@ public class ByteRegisterInstructionTest {
         Screen screen = new Screen(1);
         Cassette cassette = new Cassette();
         regs = new RegisterSet();
-        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, null);
+        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, false);
         cpu = new CPU(io);
         extendedAddress = 0xC0A0;
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test(expected = MalformedInstructionException.class)

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CPUIntegrationTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CPUIntegrationTest.java
@@ -9,11 +9,11 @@ import static org.junit.Assert.*;
 import ca.craigthomas.yacoco3e.datatypes.RegisterSet;
 import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
 import ca.craigthomas.yacoco3e.datatypes.UnsignedWord;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 public class CPUIntegrationTest
 {
@@ -22,14 +22,10 @@ public class CPUIntegrationTest
     private Memory memorySpy;
 
     private IOController ioSpy;
+    private IOController io;
 
     private RegisterSet registerSet;
     private RegisterSet registerSpy;
-
-    private UnsignedByte expectedDirectByte;
-
-    private UnsignedByte expectedExtendedByte;
-    private int expectedExtendedWord;
 
     @Before
     public void setUp() {
@@ -44,22 +40,22 @@ public class CPUIntegrationTest
 
         Screen screen = new Screen(1);
 
-        IOController io = new IOController(memorySpy, registerSpy, new EmulatedKeyboard(), screen, cassetteSpy, null);
+        io = new IOController(memorySpy, registerSpy, new EmulatedKeyboard(), screen, cassetteSpy, false);
         ioSpy = spy(io);
 
         CPU cpu = new CPU(ioSpy);
         cpuSpy = spy(cpu);
 
         ioSpy.regs.dp.set(new UnsignedByte(0xA0));
-        expectedDirectByte = new UnsignedByte(0xBA);
         ioSpy.writeByte(new UnsignedWord(0xA000), new UnsignedByte(0xBA));
-
-        expectedExtendedByte = new UnsignedByte(0xCF);
-        expectedExtendedWord = 0xCFDA;
-//        ioSpy.writeWord(extendedAddress, expectedExtendedWord);
 
         ioSpy.regs.x.set(new UnsignedWord(0xB000));
         memorySpy.enableAllRAMMode();
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
 //    @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CPUIntegrationTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CPUIntegrationTest.java
@@ -44,7 +44,7 @@ public class CPUIntegrationTest
 
         Screen screen = new Screen(1);
 
-        IOController io = new IOController(memorySpy, registerSpy, new EmulatedKeyboard(), screen, cassetteSpy);
+        IOController io = new IOController(memorySpy, registerSpy, new EmulatedKeyboard(), screen, cassetteSpy, null);
         ioSpy = spy(io);
 
         CPU cpu = new CPU(ioSpy);

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
@@ -22,7 +22,7 @@ public class CPUTest
     public void setup() throws MalformedInstructionException {
         memory = new Memory();
         regs = new RegisterSet();
-        IOController io = new IOController(memory, regs, new EmulatedKeyboard(), new Screen(1), new Cassette());
+        IOController io = new IOController(memory, regs, new EmulatedKeyboard(), new Screen(1), new Cassette(), null);
         cpu = new CPU(io);
         io.setCPU(cpu);
     }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/CPUTest.java
@@ -7,6 +7,7 @@ package ca.craigthomas.yacoco3e.components;
 import ca.craigthomas.yacoco3e.datatypes.RegisterSet;
 import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
 import ca.craigthomas.yacoco3e.datatypes.UnsignedWord;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,14 +18,20 @@ public class CPUTest
     private Memory memory;
     private RegisterSet regs;
     private CPU cpu;
+    private IOController io;
 
     @Before
     public void setup() throws MalformedInstructionException {
         memory = new Memory();
         regs = new RegisterSet();
-        IOController io = new IOController(memory, regs, new EmulatedKeyboard(), new Screen(1), new Cassette(), null);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), new Screen(1), new Cassette(), false);
         cpu = new CPU(io);
         io.setCPU(cpu);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/ConfigFileTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/ConfigFileTest.java
@@ -4,14 +4,11 @@
  */
 package ca.craigthomas.yacoco3e.components;
 
-import ca.craigthomas.yacoco3e.common.IO;
 import ca.craigthomas.yacoco3e.datatypes.ConfigFile;
-import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.InputStream;
 
 import static org.junit.Assert.*;
 
@@ -132,7 +129,7 @@ public class ConfigFileTest
     }
 
     @Test
-    public void testParseConfigFileCorrectFormat() {
+    public void testParseConfigFileCorrectFormat() throws NullPointerException {
         File resourceFile = new File(getClass().getClassLoader().getResource("test_config.yml").getFile());
         configFile = ConfigFile.parseConfigFile(resourceFile.getPath());
         assertEquals("system", configFile.getSystemROM());

--- a/src/test/java/ca/craigthomas/yacoco3e/components/DiskDriveTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/DiskDriveTest.java
@@ -26,7 +26,7 @@ public class DiskDriveTest
         Keyboard keyboard = new EmulatedKeyboard();
         Screen screen = new Screen(1);
         Cassette cassette = new Cassette();
-        IOController io = new IOController(memory, regs, keyboard, screen, cassette);
+        IOController io = new IOController(memory, regs, keyboard, screen, cassette, null);
         ioSpy = spy(io);
         CPU cpu = new CPU(io);
         ioSpy.setCPU(cpu);

--- a/src/test/java/ca/craigthomas/yacoco3e/components/DiskDriveTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/DiskDriveTest.java
@@ -6,6 +6,7 @@ package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.RegisterSet;
 import ca.craigthomas.yacoco3e.datatypes.UnsignedByte;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,6 +19,7 @@ public class DiskDriveTest
 {
     private IOController ioSpy;
     private DiskDrive drive;
+    private IOController io;
 
     @Before
     public void setUp() {
@@ -26,11 +28,16 @@ public class DiskDriveTest
         Keyboard keyboard = new EmulatedKeyboard();
         Screen screen = new Screen(1);
         Cassette cassette = new Cassette();
-        IOController io = new IOController(memory, regs, keyboard, screen, cassette, null);
+        io = new IOController(memory, regs, keyboard, screen, cassette, false);
         ioSpy = spy(io);
         CPU cpu = new CPU(io);
         ioSpy.setCPU(cpu);
         drive = new DiskDrive(ioSpy);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
@@ -5,6 +5,7 @@
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,9 +27,14 @@ public class IOControllerTest
         regs = new RegisterSet();
         screen = new Screen(1);
         cassette = new Cassette();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, false);
         cpu = new CPU(io);
         io.setCPU(cpu);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
@@ -26,7 +26,7 @@ public class IOControllerTest
         regs = new RegisterSet();
         screen = new Screen(1);
         cassette = new Cassette();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
         cpu = new CPU(io);
         io.setCPU(cpu);
     }
@@ -309,7 +309,7 @@ public class IOControllerTest
         cpu.executeInstruction();
         cpu.serviceInterrupts();
 
-        assertEquals(0xDEAD, io.getWordRegister(Register.PC).getInt());
+        assertEquals(0xDEAD, io.getWordRegister(Register.PC).get());
     }
 
     @Test
@@ -387,14 +387,14 @@ public class IOControllerTest
     public void testPushStackWritesToMemoryLocation() {
         regs.s.set(new UnsignedWord(0xA000));
         io.pushStack(Register.S, new UnsignedByte(0x98));
-        assertEquals(memory.memory[0x79FFF], new UnsignedByte(0x98).getShort());
+        assertEquals(memory.memory[0x79FFF], new UnsignedByte(0x98).get());
     }
 
     @Test
     public void testPushStackWritesToMemoryLocationUsingUStack() {
         regs.u.set(new UnsignedWord(0xA000));
         io.pushStack(Register.U, new UnsignedByte(0x98));
-        assertEquals(memory.memory[0x79FFF], new UnsignedByte(0x98).getShort());
+        assertEquals(memory.memory[0x79FFF], new UnsignedByte(0x98).get());
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/InstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/InstructionTest.java
@@ -5,6 +5,7 @@
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,8 +22,13 @@ public class InstructionTest {
         Cassette cassette = new Cassette();
         regs = new RegisterSet();
         Memory memory = new Memory();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, false);
         io.regs.pc.set(0);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/InstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/InstructionTest.java
@@ -21,7 +21,7 @@ public class InstructionTest {
         Cassette cassette = new Cassette();
         regs = new RegisterSet();
         Memory memory = new Memory();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
         io.regs.pc.set(0);
     }
 
@@ -32,10 +32,10 @@ public class InstructionTest {
         regs.pc.set(0x1234);
         instruction.getImmediate(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xAA, instruction.byteRead.getShort());
-        assertEquals(0xAABB, instruction.wordRead.getInt());
-        assertEquals(0x1235, regs.pc.getInt());
-        assertEquals(0x1234, instruction.addressRead.getInt());
+        assertEquals(0xAA, instruction.byteRead.get());
+        assertEquals(0xAABB, instruction.wordRead.get());
+        assertEquals(0x1235, regs.pc.get());
+        assertEquals(0x1234, instruction.addressRead.get());
     }
 
     @Test
@@ -45,10 +45,10 @@ public class InstructionTest {
         regs.pc.set(0x1234);
         instruction.getImmediate(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0xAA, instruction.byteRead.getShort());
-        assertEquals(0xAABB, instruction.wordRead.getInt());
-        assertEquals(0x1236, regs.pc.getInt());
-        assertEquals(0x1234, instruction.addressRead.getInt());
+        assertEquals(0xAA, instruction.byteRead.get());
+        assertEquals(0xAABB, instruction.wordRead.get());
+        assertEquals(0x1236, regs.pc.get());
+        assertEquals(0x1234, instruction.addressRead.get());
     }
 
     @Test
@@ -61,10 +61,10 @@ public class InstructionTest {
         regs.dp.set(0xAB);
         instruction.getDirect(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xFF, instruction.byteRead.getShort());
-        assertEquals(0xFFEE, instruction.wordRead.getInt());
-        assertEquals(0x00BF, regs.pc.getInt());
-        assertEquals(0xABCD, instruction.addressRead.getInt());
+        assertEquals(0xFF, instruction.byteRead.get());
+        assertEquals(0xFFEE, instruction.wordRead.get());
+        assertEquals(0x00BF, regs.pc.get());
+        assertEquals(0xABCD, instruction.addressRead.get());
     }
 
     @Test
@@ -76,10 +76,10 @@ public class InstructionTest {
         regs.pc.set(0x1234);
         instruction.getExtended(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x1236, regs.pc.getInt());
-        assertEquals(0xABCD, instruction.addressRead.getInt());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x1236, regs.pc.get());
+        assertEquals(0xABCD, instruction.addressRead.get());
     }
 
     @Test
@@ -89,10 +89,10 @@ public class InstructionTest {
         io.writeWord(0xB000, 0xAABB);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xAA, instruction.byteRead.getShort());
-        assertEquals(0xAABB, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB000, instruction.addressRead.getInt());
+        assertEquals(0xAA, instruction.byteRead.get());
+        assertEquals(0xAABB, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB000, instruction.addressRead.get());
     }
 
     @Test
@@ -104,10 +104,10 @@ public class InstructionTest {
         io.writeByte(0x0000, 0x94);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
     }
 
     @Test
@@ -118,10 +118,10 @@ public class InstructionTest {
         io.writeByte(0x0000, 0x01);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xB001, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
+        assertEquals(0xB001, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
     }
 
     @Test
@@ -132,10 +132,10 @@ public class InstructionTest {
         io.writeWord(0xAFFF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xAFFF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
+        assertEquals(0xAFFF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
     }
 
     @Test
@@ -146,11 +146,11 @@ public class InstructionTest {
         io.writeWord(0xB000, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xB000, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB001, regs.x.getInt());
+        assertEquals(0xB000, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB001, regs.x.get());
     }
 
     @Test
@@ -161,11 +161,11 @@ public class InstructionTest {
         io.writeWord(0xB000, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xB000, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB002, regs.x.getInt());
+        assertEquals(0xB000, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB002, regs.x.get());
     }
 
     @Test
@@ -177,11 +177,11 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB002, regs.x.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB002, regs.x.get());
     }
 
     @Test
@@ -192,11 +192,11 @@ public class InstructionTest {
         io.writeWord(0xAFFF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xAFFF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xAFFF, regs.x.getInt());
+        assertEquals(0xAFFF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xAFFF, regs.x.get());
     }
 
     @Test
@@ -207,11 +207,11 @@ public class InstructionTest {
         io.writeWord(0xAFFE, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xAFFE, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xAFFE, regs.x.getInt());
+        assertEquals(0xAFFE, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xAFFE, regs.x.get());
     }
 
     @Test
@@ -223,11 +223,11 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xAFFE, regs.x.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xAFFE, regs.x.get());
     }
 
     @Test
@@ -238,11 +238,11 @@ public class InstructionTest {
         io.writeWord(0xB000, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xB000, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xB000, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -254,11 +254,11 @@ public class InstructionTest {
         io.writeWord(0xB00B, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xB00B, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xB00B, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -271,11 +271,11 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -287,11 +287,11 @@ public class InstructionTest {
         io.writeWord(0xB00A, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xB00A, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xB00A, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -304,11 +304,11 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -319,11 +319,11 @@ public class InstructionTest {
         io.writeWord(0xB002, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0xB002, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0002, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xB002, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0002, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -334,11 +334,11 @@ public class InstructionTest {
         io.writeWord(0xAFFE, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0xAFFE, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0002, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xAFFE, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0002, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -350,11 +350,11 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0002, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0002, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -366,11 +366,11 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0002, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0002, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -382,11 +382,11 @@ public class InstructionTest {
         io.writeWord(0xB200, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(3, instruction.numBytesRead);
-        assertEquals(0xB200, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0003, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xB200, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0003, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -398,11 +398,11 @@ public class InstructionTest {
         io.writeWord(0xAE00, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(3, instruction.numBytesRead);
-        assertEquals(0xAE00, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0003, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xAE00, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0003, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -415,11 +415,11 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(3, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0003, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0003, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -432,11 +432,11 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(3, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0003, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0003, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -448,11 +448,11 @@ public class InstructionTest {
         io.writeWord(0xB200, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xB200, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xB200, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -465,11 +465,11 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(1, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0001, regs.pc.getInt());
-        assertEquals(0xB000, regs.x.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0001, regs.pc.get());
+        assertEquals(0xB000, regs.x.get());
     }
 
     @Test
@@ -479,10 +479,10 @@ public class InstructionTest {
         io.writeWord(0x000C, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0x000C, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x000C, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -493,10 +493,10 @@ public class InstructionTest {
         io.writeWord(0x0008, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0x0008, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x000C, regs.pc.getInt());
+        assertEquals(0x0008, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x000C, regs.pc.get());
     }
 
     @Test
@@ -507,10 +507,10 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -522,10 +522,10 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(2, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x000C, regs.pc.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x000C, regs.pc.get());
     }
 
     @Test
@@ -536,10 +536,10 @@ public class InstructionTest {
         io.writeWord(0x0203, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(3, instruction.numBytesRead);
-        assertEquals(0x0203, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0003, regs.pc.getInt());
+        assertEquals(0x0203, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0003, regs.pc.get());
     }
 
     @Test
@@ -551,10 +551,10 @@ public class InstructionTest {
         io.writeWord(0x9E03, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(3, instruction.numBytesRead);
-        assertEquals(0x9E03, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0xA003, regs.pc.getInt());
+        assertEquals(0x9E03, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0xA003, regs.pc.get());
     }
 
     @Test
@@ -566,10 +566,10 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(3, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0003, regs.pc.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0003, regs.pc.get());
     }
 
     @Test
@@ -582,10 +582,10 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(3, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0xA003, regs.pc.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0xA003, regs.pc.get());
     }
 
     @Test
@@ -597,10 +597,10 @@ public class InstructionTest {
         io.writeWord(0xBEEF, 0xDEAD);
         instruction.getIndexed(io);
         assertEquals(3, instruction.numBytesRead);
-        assertEquals(0xBEEF, instruction.addressRead.getInt());
-        assertEquals(0xDE, instruction.byteRead.getShort());
-        assertEquals(0xDEAD, instruction.wordRead.getInt());
-        assertEquals(0x0003, regs.pc.getInt());
+        assertEquals(0xBEEF, instruction.addressRead.get());
+        assertEquals(0xDE, instruction.byteRead.get());
+        assertEquals(0xDEAD, instruction.wordRead.get());
+        assertEquals(0x0003, regs.pc.get());
     }
 
     @Test(expected = MalformedInstructionException.class)

--- a/src/test/java/ca/craigthomas/yacoco3e/components/LongBranchInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/LongBranchInstructionTest.java
@@ -5,6 +5,7 @@
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,8 +24,13 @@ public class LongBranchInstructionTest {
         Cassette cassette = new Cassette();
         memory = new Memory();
         regs = new RegisterSet();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, false);
         cpu = new CPU(io);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/LongBranchInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/LongBranchInstructionTest.java
@@ -23,7 +23,7 @@ public class LongBranchInstructionTest {
         Cassette cassette = new Cassette();
         memory = new Memory();
         regs = new RegisterSet();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
         cpu = new CPU(io);
     }
 
@@ -31,14 +31,14 @@ public class LongBranchInstructionTest {
     public void testLongBranchNeverDoesNothing() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x1021);
         cpu.executeInstruction();
-        assertEquals(0x4, regs.pc.getInt());
+        assertEquals(0x4, regs.pc.get());
     }
     @Test
     public void testLongBranchAlways() throws MalformedInstructionException {
         io.writeByte(0x0000, 0x16);
         io.writeWord(0x0001, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0022, regs.pc.getInt());
+        assertEquals(0x0022, regs.pc.get());
     }
 
     @Test
@@ -46,7 +46,7 @@ public class LongBranchInstructionTest {
         io.writeByte(0x0000, 0x16);
         io.writeWord(0x0001, 0xFFFD);
         cpu.executeInstruction();
-        assertEquals(0x0000, regs.pc.getInt());
+        assertEquals(0x0000, regs.pc.get());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class LongBranchInstructionTest {
         io.writeByte(0x0000, 0x16);
         io.writeWord(0x0001, 0xFFFC);
         cpu.executeInstruction();
-        assertEquals(0xFFFF, regs.pc.getInt());
+        assertEquals(0xFFFF, regs.pc.get());
     }
 
     @Test
@@ -63,7 +63,7 @@ public class LongBranchInstructionTest {
         io.writeByte(0x0009, 0x16);
         io.writeWord(0x000A, 0x007F);
         cpu.executeInstruction();
-        assertEquals(0x008B, regs.pc.getInt());
+        assertEquals(0x008B, regs.pc.get());
     }
 
     @Test
@@ -72,7 +72,7 @@ public class LongBranchInstructionTest {
         io.writeByte(0x0056, 0x16);
         io.writeWord(0x0057, 0xFFAA);
         cpu.executeInstruction();
-        assertEquals(0x0003, regs.pc.getInt());
+        assertEquals(0x0003, regs.pc.get());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1021);
         io.writeWord(0x0002, 0x00FF);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -90,9 +90,9 @@ public class LongBranchInstructionTest {
         io.writeByte(0x1000, 0x17);
         io.writeWord(0x1001, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x1022, regs.pc.getInt());
-        assertEquals(0x03, memory.readByte(0x2FFF).getShort());
-        assertEquals(0x10, memory.readByte(0x2FFE).getShort());
+        assertEquals(0x1022, regs.pc.get());
+        assertEquals(0x03, memory.readByte(0x2FFF).get());
+        assertEquals(0x10, memory.readByte(0x2FFE).get());
     }
 
     @Test
@@ -102,9 +102,9 @@ public class LongBranchInstructionTest {
         io.writeByte(0x1021, 0x17);
         io.writeWord(0x1022, 0xFFDC);
         cpu.executeInstruction();
-        assertEquals(0x1000, regs.pc.getInt());
-        assertEquals(0x24, memory.readByte(0x2FFF).getShort());
-        assertEquals(0x10, memory.readByte(0x2FFE).getShort());
+        assertEquals(0x1000, regs.pc.get());
+        assertEquals(0x24, memory.readByte(0x2FFF).get());
+        assertEquals(0x10, memory.readByte(0x2FFE).get());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1022);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -121,7 +121,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1022);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -130,7 +130,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1022);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -138,7 +138,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1023);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -148,7 +148,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1023);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -158,7 +158,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1023);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -167,7 +167,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1023);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -176,7 +176,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1023);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -184,7 +184,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1024);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -193,7 +193,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1024);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -202,7 +202,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1025);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -210,7 +210,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1025);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -218,7 +218,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1026);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -227,7 +227,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1026);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -236,7 +236,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1027);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -244,7 +244,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1027);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -252,7 +252,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1028);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -261,7 +261,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1028);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -270,7 +270,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1029);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -278,7 +278,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x1029);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -286,7 +286,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102A);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -295,7 +295,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102A);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -304,7 +304,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102B);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -312,7 +312,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102B);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -320,7 +320,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102C);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -330,7 +330,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102C);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -339,7 +339,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102C);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -348,7 +348,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102C);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -356,7 +356,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102D);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -366,7 +366,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102D);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -375,7 +375,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102D);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -384,7 +384,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102D);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -393,7 +393,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102E);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -404,7 +404,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102E);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -414,7 +414,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102E);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -424,7 +424,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102E);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -433,7 +433,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102E);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -442,7 +442,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102E);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -450,7 +450,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102E);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -460,7 +460,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102E);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -469,7 +469,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102F);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -480,7 +480,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102F);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -490,7 +490,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102F);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -500,7 +500,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102F);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -509,7 +509,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102F);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -518,7 +518,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102F);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0023, regs.pc.getInt());
+        assertEquals(0x0023, regs.pc.get());
     }
 
     @Test
@@ -526,7 +526,7 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102F);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 
     @Test
@@ -536,6 +536,6 @@ public class LongBranchInstructionTest {
         io.writeWord(0x0000, 0x102F);
         io.writeWord(0x0002, 0x001F);
         cpu.executeInstruction();
-        assertEquals(0x0004, regs.pc.getInt());
+        assertEquals(0x0004, regs.pc.get());
     }
 }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/MemoryTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/MemoryTest.java
@@ -41,7 +41,7 @@ public class MemoryTest
     public void testGetPhysicalAddressWorksCorrectly() {
         UnsignedWord address = new UnsignedWord(0x0412);
         int par = memory.getPAR(address);
-        assertEquals(0x70412, memory.getPhysicalAddress(par, address.getInt()));
+        assertEquals(0x70412, memory.getPhysicalAddress(par, address.get()));
     }
     
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/NotImplementedInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/NotImplementedInstructionTest.java
@@ -13,7 +13,7 @@ public class NotImplementedInstructionTest {
 
     @Before
     public void setup() throws MalformedInstructionException {
-        io = new IOController(new Memory(), new RegisterSet(), new EmulatedKeyboard(), new Screen(1), new Cassette());
+        io = new IOController(new Memory(), new RegisterSet(), new EmulatedKeyboard(), new Screen(1), new Cassette(), null);
         CPU cpu = new CPU(io);
         io.setCPU(cpu);
     }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/NotImplementedInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/NotImplementedInstructionTest.java
@@ -5,6 +5,7 @@
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.RegisterSet;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,9 +14,14 @@ public class NotImplementedInstructionTest {
 
     @Before
     public void setup() throws MalformedInstructionException {
-        io = new IOController(new Memory(), new RegisterSet(), new EmulatedKeyboard(), new Screen(1), new Cassette(), null);
+        io = new IOController(new Memory(), new RegisterSet(), new EmulatedKeyboard(), new Screen(1), new Cassette(), false);
         CPU cpu = new CPU(io);
         io.setCPU(cpu);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test(expected = MalformedInstructionException.class)

--- a/src/test/java/ca/craigthomas/yacoco3e/components/PushPopInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/PushPopInstructionTest.java
@@ -22,7 +22,7 @@ public class PushPopInstructionTest {
         Cassette cassette = new Cassette();
         memory = new Memory();
         regs = new RegisterSet();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
         cpu = new CPU(io);
         io.regs.pc.set(0);
     }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/PushPopInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/PushPopInstructionTest.java
@@ -5,6 +5,7 @@
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,9 +23,14 @@ public class PushPopInstructionTest {
         Cassette cassette = new Cassette();
         memory = new Memory();
         regs = new RegisterSet();
-        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, null);
+        io = new IOController(memory, regs, new EmulatedKeyboard(), screen, cassette, false);
         cpu = new CPU(io);
         io.regs.pc.set(0);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/VoidInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/VoidInstructionTest.java
@@ -22,7 +22,7 @@ public class VoidInstructionTest {
         Screen screen = new Screen(1);
         Cassette cassette = new Cassette();
         regs = new RegisterSet();
-        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette);
+        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, null);
         cpu = new CPU(io);
         extendedAddress = 0xC0A0;
         io.regs.pc.set(0);
@@ -37,7 +37,7 @@ public class VoidInstructionTest {
     @Test
     public void testUnconditionalJumpCorrect() {
         VoidInstruction.unconditionalJump(io, null, new UnsignedWord(0xBEEF));
-        assertEquals(0xBEEF, regs.pc.getInt());
+        assertEquals(0xBEEF, regs.pc.get());
     }
 
     @Test
@@ -46,7 +46,7 @@ public class VoidInstructionTest {
         io.writeByte(0x0000, 0x0E);
         io.writeByte(0x0001, 0x0A);
         cpu.executeInstruction();
-        assertEquals(0x000A, regs.pc.getInt());
+        assertEquals(0x000A, regs.pc.get());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class VoidInstructionTest {
         io.writeWord(0x0000, 0x6E80);
         regs.x.set(extendedAddress);
         cpu.executeInstruction();
-        assertEquals(extendedAddress, regs.pc.getInt());
+        assertEquals(extendedAddress, regs.pc.get());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class VoidInstructionTest {
         io.writeByte(0x0000, 0x7E);
         io.writeWord(0x0001, extendedAddress);
         cpu.executeInstruction();
-        assertEquals(extendedAddress, regs.pc.getInt());
+        assertEquals(extendedAddress, regs.pc.get());
     }
 
     @Test
@@ -70,9 +70,9 @@ public class VoidInstructionTest {
         regs.s.set(0x0200);
         regs.pc.set(0xBEEF);
         VoidInstruction.jumpToSubroutine(io, null, new UnsignedWord(0xCAFE));
-        assertEquals(0xEF, io.readByte(new UnsignedWord(0x01FF)).getShort());
-        assertEquals(0xBE, io.readByte(new UnsignedWord(0x01FE)).getShort());
-        assertEquals(0xCAFE, regs.pc.getInt());
+        assertEquals(0xEF, io.readByte(new UnsignedWord(0x01FF)).get());
+        assertEquals(0xBE, io.readByte(new UnsignedWord(0x01FE)).get());
+        assertEquals(0xCAFE, regs.pc.get());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class VoidInstructionTest {
         regs.dp.set(0xCA);
         io.writeWord(0x0000, 0x9DFE);
         cpu.executeInstruction();
-        assertEquals(0xCAFE, regs.pc.getInt());
+        assertEquals(0xCAFE, regs.pc.get());
     }
 
     @Test
@@ -88,7 +88,7 @@ public class VoidInstructionTest {
         regs.y.set(extendedAddress);
         io.writeWord(0x0000, 0xADA0);
         cpu.executeInstruction();
-        assertEquals(extendedAddress, regs.pc.getInt());
+        assertEquals(extendedAddress, regs.pc.get());
     }
 
     @Test
@@ -96,14 +96,14 @@ public class VoidInstructionTest {
         io.writeByte(0x0000, 0xBD);
         io.writeWord(0x0001, extendedAddress);
         cpu.executeInstruction();
-        assertEquals(extendedAddress, regs.pc.getInt());
+        assertEquals(extendedAddress, regs.pc.get());
     }
 
     @Test
     public void testSWI2Correct() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x103F);
-        io.writeByte(Instruction.SWI2.getInt(), 0x56);
-        io.writeByte(Instruction.SWI2.next().getInt(), 0x78);
+        io.writeByte(Instruction.SWI2.get(), 0x56);
+        io.writeByte(Instruction.SWI2.next().get(), 0x78);
         regs.cc.or(CC_N);
         regs.cc.or(CC_V);
         regs.s.set(0xA000);
@@ -114,18 +114,18 @@ public class VoidInstructionTest {
         regs.b.set(0xCD);
         regs.a.set(0xEF);
         cpu.executeInstruction();
-        assertEquals(0x02, io.readByte(0x9FFF).getShort());
-        assertEquals(0x00, io.readByte(0x9FFE).getShort());
-        assertEquals(0xAD, io.readByte(0x9FFD).getShort());
-        assertEquals(0xDE, io.readByte(0x9FFC).getShort());
-        assertEquals(0xEF, io.readByte(0x9FFB).getShort());
-        assertEquals(0xBE, io.readByte(0x9FFA).getShort());
-        assertEquals(0xFE, io.readByte(0x9FF9).getShort());
-        assertEquals(0xCA, io.readByte(0x9FF8).getShort());
-        assertEquals(0xAB, io.readByte(0x9FF7).getShort());
-        assertEquals(0xCD, io.readByte(0x9FF6).getShort());
-        assertEquals(0xEF, io.readByte(0x9FF5).getShort());
-        assertEquals(0x8A, io.readByte(0x9FF4).getShort());
+        assertEquals(0x02, io.readByte(0x9FFF).get());
+        assertEquals(0x00, io.readByte(0x9FFE).get());
+        assertEquals(0xAD, io.readByte(0x9FFD).get());
+        assertEquals(0xDE, io.readByte(0x9FFC).get());
+        assertEquals(0xEF, io.readByte(0x9FFB).get());
+        assertEquals(0xBE, io.readByte(0x9FFA).get());
+        assertEquals(0xFE, io.readByte(0x9FF9).get());
+        assertEquals(0xCA, io.readByte(0x9FF8).get());
+        assertEquals(0xAB, io.readByte(0x9FF7).get());
+        assertEquals(0xCD, io.readByte(0x9FF6).get());
+        assertEquals(0xEF, io.readByte(0x9FF5).get());
+        assertEquals(0x8A, io.readByte(0x9FF4).get());
 //        assertEquals(0x5678, regs.pc.getInt());
     }
 
@@ -143,18 +143,18 @@ public class VoidInstructionTest {
         regs.b.set(0xCD);
         regs.a.set(0xEF);
         cpu.executeInstruction();
-        assertEquals(0x02, io.readByte(0x9FFF).getShort());
-        assertEquals(0x00, io.readByte(0x9FFE).getShort());
-        assertEquals(0xAD, io.readByte(0x9FFD).getShort());
-        assertEquals(0xDE, io.readByte(0x9FFC).getShort());
-        assertEquals(0xEF, io.readByte(0x9FFB).getShort());
-        assertEquals(0xBE, io.readByte(0x9FFA).getShort());
-        assertEquals(0xFE, io.readByte(0x9FF9).getShort());
-        assertEquals(0xCA, io.readByte(0x9FF8).getShort());
-        assertEquals(0xAB, io.readByte(0x9FF7).getShort());
-        assertEquals(0xCD, io.readByte(0x9FF6).getShort());
-        assertEquals(0xEF, io.readByte(0x9FF5).getShort());
-        assertEquals(0x8A, io.readByte(0x9FF4).getShort());
+        assertEquals(0x02, io.readByte(0x9FFF).get());
+        assertEquals(0x00, io.readByte(0x9FFE).get());
+        assertEquals(0xAD, io.readByte(0x9FFD).get());
+        assertEquals(0xDE, io.readByte(0x9FFC).get());
+        assertEquals(0xEF, io.readByte(0x9FFB).get());
+        assertEquals(0xBE, io.readByte(0x9FFA).get());
+        assertEquals(0xFE, io.readByte(0x9FF9).get());
+        assertEquals(0xCA, io.readByte(0x9FF8).get());
+        assertEquals(0xAB, io.readByte(0x9FF7).get());
+        assertEquals(0xCD, io.readByte(0x9FF6).get());
+        assertEquals(0xEF, io.readByte(0x9FF5).get());
+        assertEquals(0x8A, io.readByte(0x9FF4).get());
 //        assertEquals(0x5678, regs.pc.getInt());
     }
 
@@ -172,18 +172,18 @@ public class VoidInstructionTest {
         regs.b.set(0xCD);
         regs.a.set(0xEF);
         cpu.executeInstruction();
-        assertEquals(0x01, io.readByte(0x9FFF).getShort());
-        assertEquals(0x00, io.readByte(0x9FFE).getShort());
-        assertEquals(0xAD, io.readByte(0x9FFD).getShort());
-        assertEquals(0xDE, io.readByte(0x9FFC).getShort());
-        assertEquals(0xEF, io.readByte(0x9FFB).getShort());
-        assertEquals(0xBE, io.readByte(0x9FFA).getShort());
-        assertEquals(0xFE, io.readByte(0x9FF9).getShort());
-        assertEquals(0xCA, io.readByte(0x9FF8).getShort());
-        assertEquals(0xAB, io.readByte(0x9FF7).getShort());
-        assertEquals(0xCD, io.readByte(0x9FF6).getShort());
-        assertEquals(0xEF, io.readByte(0x9FF5).getShort());
-        assertEquals(0x8A, io.readByte(0x9FF4).getShort());
+        assertEquals(0x01, io.readByte(0x9FFF).get());
+        assertEquals(0x00, io.readByte(0x9FFE).get());
+        assertEquals(0xAD, io.readByte(0x9FFD).get());
+        assertEquals(0xDE, io.readByte(0x9FFC).get());
+        assertEquals(0xEF, io.readByte(0x9FFB).get());
+        assertEquals(0xBE, io.readByte(0x9FFA).get());
+        assertEquals(0xFE, io.readByte(0x9FF9).get());
+        assertEquals(0xCA, io.readByte(0x9FF8).get());
+        assertEquals(0xAB, io.readByte(0x9FF7).get());
+        assertEquals(0xCD, io.readByte(0x9FF6).get());
+        assertEquals(0xEF, io.readByte(0x9FF5).get());
+        assertEquals(0x8A, io.readByte(0x9FF4).get());
 //        assertEquals(0x5678, regs.pc.getInt());
     }
 
@@ -193,7 +193,7 @@ public class VoidInstructionTest {
         io.writeByte(0x0000, 0x39);
         io.writeWord(0x0020, 0xBEEF);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.pc.getInt());
+        assertEquals(0xBEEF, regs.pc.get());
     }
 
     @Test
@@ -214,14 +214,14 @@ public class VoidInstructionTest {
         io.writeByte(0x9FF4, CC_E);
         io.writeByte(0x00, 0x3B);
         cpu.executeInstruction();
-        assertEquals(0x01, regs.a.getShort());
-        assertEquals(0x02, regs.b.getShort());
-        assertEquals(0x03, regs.dp.getShort());
-        assertEquals(CC_E, regs.cc.getShort());
-        assertEquals(0x5566, regs.x.getInt());
-        assertEquals(0x7788, regs.y.getInt());
-        assertEquals(0x99AA, regs.u.getInt());
-        assertEquals(0xBBCC, regs.pc.getInt());
+        assertEquals(0x01, regs.a.get());
+        assertEquals(0x02, regs.b.get());
+        assertEquals(0x03, regs.dp.get());
+        assertEquals(CC_E, regs.cc.get());
+        assertEquals(0x5566, regs.x.get());
+        assertEquals(0x7788, regs.y.get());
+        assertEquals(0x99AA, regs.u.get());
+        assertEquals(0xBBCC, regs.pc.get());
     }
 
     @Test
@@ -232,7 +232,7 @@ public class VoidInstructionTest {
         io.writeByte(0x9FF3, 0x00);
         io.writeByte(0x0000, 0x3B);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.pc.getInt());
+        assertEquals(0xBEEF, regs.pc.get());
     }
 
     @Test
@@ -241,8 +241,8 @@ public class VoidInstructionTest {
         regs.x.set(0xBEEF);
         io.writeWord(0x0000, 0x1F01);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.getD().getInt());
-        assertEquals(0xDEAD, regs.x.getInt());
+        assertEquals(0xDEAD, regs.getD().get());
+        assertEquals(0xDEAD, regs.x.get());
     }
 
     @Test
@@ -251,8 +251,8 @@ public class VoidInstructionTest {
         regs.setD(0xBEEF);
         io.writeWord(0x0000, 0x1F10);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.x.getInt());
-        assertEquals(0xDEAD, regs.getD().getInt());
+        assertEquals(0xDEAD, regs.x.get());
+        assertEquals(0xDEAD, regs.getD().get());
     }
 
     @Test
@@ -261,8 +261,8 @@ public class VoidInstructionTest {
         regs.y.set(0xBEEF);
         io.writeWord(0x0000, 0x1F02);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.getD().getInt());
-        assertEquals(0xDEAD, regs.y.getInt());
+        assertEquals(0xDEAD, regs.getD().get());
+        assertEquals(0xDEAD, regs.y.get());
     }
 
     @Test
@@ -271,8 +271,8 @@ public class VoidInstructionTest {
         regs.setD(0xBEEF);
         io.writeWord(0x0000, 0x1F20);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.y.getInt());
-        assertEquals(0xDEAD, regs.getD().getInt());
+        assertEquals(0xDEAD, regs.y.get());
+        assertEquals(0xDEAD, regs.getD().get());
     }
 
     @Test
@@ -281,8 +281,8 @@ public class VoidInstructionTest {
         regs.u.set(0xBEEF);
         io.writeWord(0x0000, 0x1F03);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.getD().getInt());
-        assertEquals(0xDEAD, regs.u.getInt());
+        assertEquals(0xDEAD, regs.getD().get());
+        assertEquals(0xDEAD, regs.u.get());
     }
 
     @Test
@@ -291,8 +291,8 @@ public class VoidInstructionTest {
         regs.setD(0xBEEF);
         io.writeWord(0x0000, 0x1F30);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.u.getInt());
-        assertEquals(0xDEAD, regs.getD().getInt());
+        assertEquals(0xDEAD, regs.u.get());
+        assertEquals(0xDEAD, regs.getD().get());
     }
 
     @Test
@@ -301,8 +301,8 @@ public class VoidInstructionTest {
         regs.s.set(0xBEEF);
         io.writeWord(0x0000, 0x1F04);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.getD().getInt());
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xDEAD, regs.getD().get());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
@@ -311,8 +311,8 @@ public class VoidInstructionTest {
         regs.setD(0xBEEF);
         io.writeWord(0x0000, 0x1F40);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.s.getInt());
-        assertEquals(0xDEAD, regs.getD().getInt());
+        assertEquals(0xDEAD, regs.s.get());
+        assertEquals(0xDEAD, regs.getD().get());
     }
 
     @Test
@@ -320,8 +320,8 @@ public class VoidInstructionTest {
         regs.setD(0xDEAD);
         io.writeWord(0x0000, 0x1F05);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.getD().getInt());
-        assertEquals(0xDEAD, regs.pc.getInt());
+        assertEquals(0xDEAD, regs.getD().get());
+        assertEquals(0xDEAD, regs.pc.get());
     }
 
     @Test
@@ -330,8 +330,8 @@ public class VoidInstructionTest {
         io.writeWord(0x0000, 0x1F50);
         cpu.executeInstruction();
         /* PC will have advanced */
-        assertEquals(0x0002, regs.pc.getInt());
-        assertEquals(0x0002, regs.getD().getInt());
+        assertEquals(0x0002, regs.pc.get());
+        assertEquals(0x0002, regs.getD().get());
     }
 
     @Test
@@ -340,8 +340,8 @@ public class VoidInstructionTest {
         regs.y.set(0xBEEF);
         io.writeWord(0x0000, 0x1F12);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.x.getInt());
-        assertEquals(0xDEAD, regs.y.getInt());
+        assertEquals(0xDEAD, regs.x.get());
+        assertEquals(0xDEAD, regs.y.get());
     }
 
     @Test
@@ -350,8 +350,8 @@ public class VoidInstructionTest {
         regs.x.set(0xBEEF);
         io.writeWord(0x0000, 0x1F21);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.y.getInt());
-        assertEquals(0xDEAD, regs.x.getInt());
+        assertEquals(0xDEAD, regs.y.get());
+        assertEquals(0xDEAD, regs.x.get());
     }
 
     @Test
@@ -360,8 +360,8 @@ public class VoidInstructionTest {
         regs.u.set(0xBEEF);
         io.writeWord(0x0000, 0x1F13);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.x.getInt());
-        assertEquals(0xDEAD, regs.u.getInt());
+        assertEquals(0xDEAD, regs.x.get());
+        assertEquals(0xDEAD, regs.u.get());
     }
 
     @Test
@@ -370,8 +370,8 @@ public class VoidInstructionTest {
         regs.x.set(0xBEEF);
         io.writeWord(0x0000, 0x1F31);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.u.getInt());
-        assertEquals(0xDEAD, regs.x.getInt());
+        assertEquals(0xDEAD, regs.u.get());
+        assertEquals(0xDEAD, regs.x.get());
     }
 
     @Test
@@ -380,8 +380,8 @@ public class VoidInstructionTest {
         regs.s.set(0xBEEF);
         io.writeWord(0x0000, 0x1F14);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.x.getInt());
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xDEAD, regs.x.get());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
@@ -390,8 +390,8 @@ public class VoidInstructionTest {
         regs.x.set(0xBEEF);
         io.writeWord(0x0000, 0x1F41);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.s.getInt());
-        assertEquals(0xDEAD, regs.x.getInt());
+        assertEquals(0xDEAD, regs.s.get());
+        assertEquals(0xDEAD, regs.x.get());
     }
 
     @Test
@@ -399,8 +399,8 @@ public class VoidInstructionTest {
         regs.x.set(0xDEAD);
         io.writeWord(0x0000, 0x1F15);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.x.getInt());
-        assertEquals(0xDEAD, regs.pc.getInt());
+        assertEquals(0xDEAD, regs.x.get());
+        assertEquals(0xDEAD, regs.pc.get());
     }
 
     @Test
@@ -409,8 +409,8 @@ public class VoidInstructionTest {
         io.writeWord(0x0000, 0x1F51);
         cpu.executeInstruction();
         /* PC will have advanced */
-        assertEquals(0x0002, regs.pc.getInt());
-        assertEquals(0x0002, regs.x.getInt());
+        assertEquals(0x0002, regs.pc.get());
+        assertEquals(0x0002, regs.x.get());
     }
 
     @Test
@@ -419,8 +419,8 @@ public class VoidInstructionTest {
         regs.u.set(0xBEEF);
         io.writeWord(0x0000, 0x1F23);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.y.getInt());
-        assertEquals(0xDEAD, regs.u.getInt());
+        assertEquals(0xDEAD, regs.y.get());
+        assertEquals(0xDEAD, regs.u.get());
     }
 
     @Test
@@ -429,8 +429,8 @@ public class VoidInstructionTest {
         regs.y.set(0xBEEF);
         io.writeWord(0x0000, 0x1F32);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.u.getInt());
-        assertEquals(0xDEAD, regs.y.getInt());
+        assertEquals(0xDEAD, regs.u.get());
+        assertEquals(0xDEAD, regs.y.get());
     }
 
     @Test
@@ -439,8 +439,8 @@ public class VoidInstructionTest {
         regs.s.set(0xBEEF);
         io.writeWord(0x0000, 0x1F24);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.y.getInt());
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xDEAD, regs.y.get());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
@@ -449,8 +449,8 @@ public class VoidInstructionTest {
         regs.y.set(0xBEEF);
         io.writeWord(0x0000, 0x1F42);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.s.getInt());
-        assertEquals(0xDEAD, regs.y.getInt());
+        assertEquals(0xDEAD, regs.s.get());
+        assertEquals(0xDEAD, regs.y.get());
     }
 
     @Test
@@ -458,8 +458,8 @@ public class VoidInstructionTest {
         regs.y.set(0xDEAD);
         io.writeWord(0x0000, 0x1F25);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.y.getInt());
-        assertEquals(0xDEAD, regs.pc.getInt());
+        assertEquals(0xDEAD, regs.y.get());
+        assertEquals(0xDEAD, regs.pc.get());
     }
 
     @Test
@@ -468,8 +468,8 @@ public class VoidInstructionTest {
         io.writeWord(0x0000, 0x1F52);
         cpu.executeInstruction();
         /* PC will have advanced */
-        assertEquals(0x0002, regs.pc.getInt());
-        assertEquals(0x0002, regs.y.getInt());
+        assertEquals(0x0002, regs.pc.get());
+        assertEquals(0x0002, regs.y.get());
     }
 
     @Test
@@ -478,8 +478,8 @@ public class VoidInstructionTest {
         io.regs.s.set(0xBEEF);
         io.writeWord(0x0000, 0x1F34);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.u.getInt());
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xDEAD, regs.u.get());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
@@ -488,8 +488,8 @@ public class VoidInstructionTest {
         regs.u.set(0xBEEF);
         io.writeWord(0x0000, 0x1F43);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.s.getInt());
-        assertEquals(0xDEAD, regs.u.getInt());
+        assertEquals(0xDEAD, regs.s.get());
+        assertEquals(0xDEAD, regs.u.get());
     }
 
     @Test
@@ -497,8 +497,8 @@ public class VoidInstructionTest {
         regs.u.set(0xDEAD);
         io.writeWord(0x0000, 0x1F35);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.u.getInt());
-        assertEquals(0xDEAD, regs.pc.getInt());
+        assertEquals(0xDEAD, regs.u.get());
+        assertEquals(0xDEAD, regs.pc.get());
     }
 
     @Test
@@ -507,8 +507,8 @@ public class VoidInstructionTest {
         io.writeWord(0x0000, 0x1F53);
         cpu.executeInstruction();
         /* PC will have advanced */
-        assertEquals(0x0002, regs.pc.getInt());
-        assertEquals(0x0002, regs.u.getInt());
+        assertEquals(0x0002, regs.pc.get());
+        assertEquals(0x0002, regs.u.get());
     }
 
     @Test
@@ -516,8 +516,8 @@ public class VoidInstructionTest {
         regs.s.set(0xDEAD);
         io.writeWord(0x0000, 0x1F45);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.s.getInt());
-        assertEquals(0xDEAD, regs.pc.getInt());
+        assertEquals(0xDEAD, regs.s.get());
+        assertEquals(0xDEAD, regs.pc.get());
     }
 
     @Test
@@ -526,8 +526,8 @@ public class VoidInstructionTest {
         io.writeWord(0x0000, 0x1F54);
         cpu.executeInstruction();
         /* PC will have advanced */
-        assertEquals(0x0002, regs.pc.getInt());
-        assertEquals(0x0002, regs.s.getInt());
+        assertEquals(0x0002, regs.pc.get());
+        assertEquals(0x0002, regs.s.get());
     }
 
     @Test
@@ -536,8 +536,8 @@ public class VoidInstructionTest {
         regs.b.set(0xBE);
         io.writeWord(0x0000, 0x1F89);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.a.getShort());
-        assertEquals(0xDE, regs.b.getShort());
+        assertEquals(0xDE, regs.a.get());
+        assertEquals(0xDE, regs.b.get());
     }
 
     @Test
@@ -546,8 +546,8 @@ public class VoidInstructionTest {
         regs.a.set(0xBE);
         io.writeWord(0x0000, 0x1F98);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.a.getShort());
-        assertEquals(0xDE, regs.b.getShort());
+        assertEquals(0xDE, regs.a.get());
+        assertEquals(0xDE, regs.b.get());
     }
 
     @Test
@@ -556,8 +556,8 @@ public class VoidInstructionTest {
         regs.cc.set(0xBE);
         io.writeWord(0x0000, 0x1F8A);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.a.getShort());
-        assertEquals(0xDE, regs.cc.getShort());
+        assertEquals(0xDE, regs.a.get());
+        assertEquals(0xDE, regs.cc.get());
     }
 
     @Test
@@ -566,8 +566,8 @@ public class VoidInstructionTest {
         regs.a.set(0xBE);
         io.writeWord(0x0000, 0x1FA8);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.cc.getShort());
-        assertEquals(0xDE, regs.a.getShort());
+        assertEquals(0xDE, regs.cc.get());
+        assertEquals(0xDE, regs.a.get());
     }
 
     @Test
@@ -576,8 +576,8 @@ public class VoidInstructionTest {
         regs.dp.set(0xBE);
         io.writeWord(0x0000, 0x1F8B);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.a.getShort());
-        assertEquals(0xDE, regs.dp.getShort());
+        assertEquals(0xDE, regs.a.get());
+        assertEquals(0xDE, regs.dp.get());
     }
 
     @Test
@@ -586,8 +586,8 @@ public class VoidInstructionTest {
         regs.a.set(0xBE);
         io.writeWord(0x0000, 0x1FB8);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.dp.getShort());
-        assertEquals(0xDE, regs.a.getShort());
+        assertEquals(0xDE, regs.dp.get());
+        assertEquals(0xDE, regs.a.get());
     }
 
     @Test
@@ -596,8 +596,8 @@ public class VoidInstructionTest {
         regs.cc.set(0xBE);
         io.writeWord(0x0000, 0x1F9A);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.b.getShort());
-        assertEquals(0xDE, regs.cc.getShort());
+        assertEquals(0xDE, regs.b.get());
+        assertEquals(0xDE, regs.cc.get());
     }
 
     @Test
@@ -606,8 +606,8 @@ public class VoidInstructionTest {
         regs.b.set(0xBE);
         io.writeWord(0x0000, 0x1FA9);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.cc.getShort());
-        assertEquals(0xDE, regs.b.getShort());
+        assertEquals(0xDE, regs.cc.get());
+        assertEquals(0xDE, regs.b.get());
     }
 
     @Test
@@ -616,8 +616,8 @@ public class VoidInstructionTest {
         regs.dp.set(0xBE);
         io.writeWord(0x0000, 0x1F9B);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.b.getShort());
-        assertEquals(0xDE, regs.dp.getShort());
+        assertEquals(0xDE, regs.b.get());
+        assertEquals(0xDE, regs.dp.get());
     }
 
     @Test
@@ -626,8 +626,8 @@ public class VoidInstructionTest {
         regs.a.set(0xBE);
         io.writeWord(0x0000, 0x1FB9);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.dp.getShort());
-        assertEquals(0xDE, regs.b.getShort());
+        assertEquals(0xDE, regs.dp.get());
+        assertEquals(0xDE, regs.b.get());
     }
 
     @Test
@@ -636,8 +636,8 @@ public class VoidInstructionTest {
         regs.dp.set(0xBE);
         io.writeWord(0x0000, 0x1FAB);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.cc.getShort());
-        assertEquals(0xDE, regs.dp.getShort());
+        assertEquals(0xDE, regs.cc.get());
+        assertEquals(0xDE, regs.dp.get());
     }
 
     @Test
@@ -646,8 +646,8 @@ public class VoidInstructionTest {
         regs.cc.set(0xBE);
         io.writeWord(0x0000, 0x1FBA);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.dp.getShort());
-        assertEquals(0xDE, regs.cc.getShort());
+        assertEquals(0xDE, regs.dp.get());
+        assertEquals(0xDE, regs.cc.get());
     }
 
     @Test
@@ -655,7 +655,7 @@ public class VoidInstructionTest {
         regs.a.set(0xDE);
         io.writeWord(0x0000, 0x1F88);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.a.getShort());
+        assertEquals(0xDE, regs.a.get());
     }
 
     @Test
@@ -663,7 +663,7 @@ public class VoidInstructionTest {
         regs.setD(0xDEAD);
         io.writeWord(0x0000, 0x1F00);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.getD().getInt());
+        assertEquals(0xDEAD, regs.getD().get());
     }
 
     @Test
@@ -671,7 +671,7 @@ public class VoidInstructionTest {
         regs.x.set(0xDEAD);
         io.writeWord(0x0000, 0x1F11);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.x.getInt());
+        assertEquals(0xDEAD, regs.x.get());
     }
 
     @Test
@@ -679,7 +679,7 @@ public class VoidInstructionTest {
         regs.y.set(0xDEAD);
         io.writeWord(0x0000, 0x1F22);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.y.getInt());
+        assertEquals(0xDEAD, regs.y.get());
     }
 
     @Test
@@ -687,7 +687,7 @@ public class VoidInstructionTest {
         regs.u.set(0xDEAD);
         io.writeWord(0x0000, 0x1F33);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.u.getInt());
+        assertEquals(0xDEAD, regs.u.get());
     }
 
     @Test
@@ -695,14 +695,14 @@ public class VoidInstructionTest {
         regs.s.set(0xDEAD);
         io.writeWord(0x0000, 0x1F44);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
     public void testTransferPCtoPC() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x1F55);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -710,7 +710,7 @@ public class VoidInstructionTest {
         regs.b.set(0xDE);
         io.writeWord(0x0000, 0x1F99);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.b.getShort());
+        assertEquals(0xDE, regs.b.get());
     }
 
     @Test
@@ -718,7 +718,7 @@ public class VoidInstructionTest {
         regs.cc.set(0xDE);
         io.writeWord(0x0000, 0x1FAA);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.cc.getShort());
+        assertEquals(0xDE, regs.cc.get());
     }
 
     @Test
@@ -726,7 +726,7 @@ public class VoidInstructionTest {
         regs.dp.set(0xDE);
         io.writeWord(0x0000, 0x1FBB);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.dp.getShort());
+        assertEquals(0xDE, regs.dp.get());
     }
 
     @Test(expected = RuntimeException.class)
@@ -741,8 +741,8 @@ public class VoidInstructionTest {
         regs.x.set(0xBEEF);
         io.writeWord(0x0000, 0x1E01);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.getD().getInt());
-        assertEquals(0xDEAD, regs.x.getInt());
+        assertEquals(0xBEEF, regs.getD().get());
+        assertEquals(0xDEAD, regs.x.get());
     }
 
     @Test
@@ -751,8 +751,8 @@ public class VoidInstructionTest {
         regs.y.set(0xBEEF);
         io.writeWord(0x0000, 0x1E02);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.getD().getInt());
-        assertEquals(0xDEAD, regs.y.getInt());
+        assertEquals(0xBEEF, regs.getD().get());
+        assertEquals(0xDEAD, regs.y.get());
     }
 
     @Test
@@ -761,8 +761,8 @@ public class VoidInstructionTest {
         regs.u.set(0xBEEF);
         io.writeWord(0x0000, 0x1E03);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.getD().getInt());
-        assertEquals(0xDEAD, regs.u.getInt());
+        assertEquals(0xBEEF, regs.getD().get());
+        assertEquals(0xDEAD, regs.u.get());
     }
 
     @Test
@@ -771,8 +771,8 @@ public class VoidInstructionTest {
         regs.s.set(0xBEEF);
         io.writeWord(0x0000, 0x1E04);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.getD().getInt());
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xBEEF, regs.getD().get());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
@@ -780,8 +780,8 @@ public class VoidInstructionTest {
         regs.setD(0xDEAD);
         io.writeWord(0x0000, 0x1E05);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.pc.getInt());
-        assertEquals(0x0002, regs.getD().getInt());
+        assertEquals(0xDEAD, regs.pc.get());
+        assertEquals(0x0002, regs.getD().get());
     }
 
     @Test
@@ -790,8 +790,8 @@ public class VoidInstructionTest {
         regs.y.set(0xBEEF);
         io.writeWord(0x0000, 0x1E12);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.x.getInt());
-        assertEquals(0xDEAD, regs.y.getInt());
+        assertEquals(0xBEEF, regs.x.get());
+        assertEquals(0xDEAD, regs.y.get());
     }
 
     @Test
@@ -800,8 +800,8 @@ public class VoidInstructionTest {
         regs.u.set(0xBEEF);
         io.writeWord(0x0000, 0x1E13);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.x.getInt());
-        assertEquals(0xDEAD, regs.u.getInt());
+        assertEquals(0xBEEF, regs.x.get());
+        assertEquals(0xDEAD, regs.u.get());
     }
 
     @Test
@@ -810,8 +810,8 @@ public class VoidInstructionTest {
         regs.s.set(0xBEEF);
         io.writeWord(0x0000, 0x1E14);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.x.getInt());
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xBEEF, regs.x.get());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
@@ -819,8 +819,8 @@ public class VoidInstructionTest {
         regs.x.set(0xDEAD);
         io.writeWord(0x0000, 0x1E15);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.x.getInt());
-        assertEquals(0xDEAD, regs.pc.getInt());
+        assertEquals(0x0002, regs.x.get());
+        assertEquals(0xDEAD, regs.pc.get());
     }
 
     @Test
@@ -829,8 +829,8 @@ public class VoidInstructionTest {
         regs.u.set(0xBEEF);
         io.writeWord(0x0000, 0x1E23);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.y.getInt());
-        assertEquals(0xDEAD, regs.u.getInt());
+        assertEquals(0xBEEF, regs.y.get());
+        assertEquals(0xDEAD, regs.u.get());
     }
 
     @Test
@@ -839,8 +839,8 @@ public class VoidInstructionTest {
         regs.s.set(0xBEEF);
         io.writeWord(0x0000, 0x1E24);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.y.getInt());
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xBEEF, regs.y.get());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
@@ -848,8 +848,8 @@ public class VoidInstructionTest {
         regs.y.set(0xDEAD);
         io.writeWord(0x0000, 0x1E25);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.y.getInt());
-        assertEquals(0xDEAD, regs.pc.getInt());
+        assertEquals(0x0002, regs.y.get());
+        assertEquals(0xDEAD, regs.pc.get());
     }
 
     @Test
@@ -858,8 +858,8 @@ public class VoidInstructionTest {
         regs.s.set(0xBEEF);
         io.writeWord(0x0000, 0x1E34);
         cpu.executeInstruction();
-        assertEquals(0xBEEF, regs.u.getInt());
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xBEEF, regs.u.get());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
@@ -867,8 +867,8 @@ public class VoidInstructionTest {
         regs.u.set(0xDEAD);
         io.writeWord(0x0000, 0x1E35);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.u.getInt());
-        assertEquals(0xDEAD, regs.pc.getInt());
+        assertEquals(0x0002, regs.u.get());
+        assertEquals(0xDEAD, regs.pc.get());
     }
 
     @Test
@@ -876,8 +876,8 @@ public class VoidInstructionTest {
         regs.s.set(0xDEAD);
         io.writeWord(0x0000, 0x1E45);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.s.getInt());
-        assertEquals(0xDEAD, regs.pc.getInt());
+        assertEquals(0x0002, regs.s.get());
+        assertEquals(0xDEAD, regs.pc.get());
     }
 
     @Test
@@ -886,8 +886,8 @@ public class VoidInstructionTest {
         regs.b.set(0xAD);
         io.writeWord(0x0000, 0x1E89);
         cpu.executeInstruction();
-        assertEquals(0xAD, regs.a.getShort());
-        assertEquals(0xDE, regs.b.getShort());
+        assertEquals(0xAD, regs.a.get());
+        assertEquals(0xDE, regs.b.get());
     }
 
     @Test
@@ -896,8 +896,8 @@ public class VoidInstructionTest {
         regs.dp.set(0xAD);
         io.writeWord(0x0000, 0x1E8B);
         cpu.executeInstruction();
-        assertEquals(0xAD, regs.a.getShort());
-        assertEquals(0xDE, regs.dp.getShort());
+        assertEquals(0xAD, regs.a.get());
+        assertEquals(0xDE, regs.dp.get());
     }
 
     @Test
@@ -906,8 +906,8 @@ public class VoidInstructionTest {
         regs.cc.set(0xAD);
         io.writeWord(0x0000, 0x1E8A);
         cpu.executeInstruction();
-        assertEquals(0xAD, regs.a.getShort());
-        assertEquals(0xDE, regs.cc.getShort());
+        assertEquals(0xAD, regs.a.get());
+        assertEquals(0xDE, regs.cc.get());
     }
 
     @Test
@@ -916,8 +916,8 @@ public class VoidInstructionTest {
         regs.cc.set(0xAD);
         io.writeWord(0x0000, 0x1E9A);
         cpu.executeInstruction();
-        assertEquals(0xAD, regs.b.getShort());
-        assertEquals(0xDE, regs.cc.getShort());
+        assertEquals(0xAD, regs.b.get());
+        assertEquals(0xDE, regs.cc.get());
     }
 
     @Test
@@ -926,8 +926,8 @@ public class VoidInstructionTest {
         regs.dp.set(0xAD);
         io.writeWord(0x0000, 0x1E9B);
         cpu.executeInstruction();
-        assertEquals(0xAD, regs.b.getShort());
-        assertEquals(0xDE, regs.dp.getShort());
+        assertEquals(0xAD, regs.b.get());
+        assertEquals(0xDE, regs.dp.get());
     }
 
     @Test
@@ -936,8 +936,8 @@ public class VoidInstructionTest {
         regs.dp.set(0xAD);
         io.writeWord(0x0000, 0x1EAB);
         cpu.executeInstruction();
-        assertEquals(0xAD, regs.cc.getShort());
-        assertEquals(0xDE, regs.dp.getShort());
+        assertEquals(0xAD, regs.cc.get());
+        assertEquals(0xDE, regs.dp.get());
     }
 
     @Test
@@ -945,7 +945,7 @@ public class VoidInstructionTest {
         regs.a.set(0xDE);
         io.writeWord(0x0000, 0x1E88);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.a.getShort());
+        assertEquals(0xDE, regs.a.get());
     }
 
     @Test
@@ -953,7 +953,7 @@ public class VoidInstructionTest {
         regs.setD(0xDEAD);
         io.writeWord(0x0000, 0x1E00);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.getD().getInt());
+        assertEquals(0xDEAD, regs.getD().get());
     }
 
     @Test
@@ -961,7 +961,7 @@ public class VoidInstructionTest {
         regs.x.set(0xDEAD);
         io.writeWord(0x0000, 0x1E11);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.x.getInt());
+        assertEquals(0xDEAD, regs.x.get());
     }
 
     @Test
@@ -969,7 +969,7 @@ public class VoidInstructionTest {
         regs.y.set(0xDEAD);
         io.writeWord(0x0000, 0x1E22);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.y.getInt());
+        assertEquals(0xDEAD, regs.y.get());
     }
 
     @Test
@@ -977,7 +977,7 @@ public class VoidInstructionTest {
         regs.u.set(0xDEAD);
         io.writeWord(0x0000, 0x1E33);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.u.getInt());
+        assertEquals(0xDEAD, regs.u.get());
     }
 
     @Test
@@ -985,14 +985,14 @@ public class VoidInstructionTest {
         regs.s.set(0xDEAD);
         io.writeWord(0x0000, 0x1E44);
         cpu.executeInstruction();
-        assertEquals(0xDEAD, regs.s.getInt());
+        assertEquals(0xDEAD, regs.s.get());
     }
 
     @Test
     public void testExchangePCtoPC() throws MalformedInstructionException {
         io.writeWord(0x0000, 0x1E55);
         cpu.executeInstruction();
-        assertEquals(0x0002, regs.pc.getInt());
+        assertEquals(0x0002, regs.pc.get());
     }
 
     @Test
@@ -1000,7 +1000,7 @@ public class VoidInstructionTest {
         regs.b.set(0xDE);
         io.writeWord(0x0000, 0x1E99);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.b.getShort());
+        assertEquals(0xDE, regs.b.get());
     }
 
     @Test
@@ -1008,7 +1008,7 @@ public class VoidInstructionTest {
         regs.cc.set(0xDE);
         io.writeWord(0x0000, 0x1EAA);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.cc.getShort());
+        assertEquals(0xDE, regs.cc.get());
     }
 
     @Test
@@ -1016,7 +1016,7 @@ public class VoidInstructionTest {
         regs.dp.set(0xDE);
         io.writeWord(0x0000, 0x1EBB);
         cpu.executeInstruction();
-        assertEquals(0xDE, regs.dp.getShort());
+        assertEquals(0xDE, regs.dp.get());
     }
 
     @Test(expected = RuntimeException.class)
@@ -1029,6 +1029,6 @@ public class VoidInstructionTest {
     public void testNopIncrementsPC() throws MalformedInstructionException {
         io.writeByte(0x0000, 0x12);
         cpu.executeInstruction();
-        assertEquals(0x0001, regs.pc.getInt());
+        assertEquals(0x0001, regs.pc.get());
     }
 }

--- a/src/test/java/ca/craigthomas/yacoco3e/components/VoidInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/VoidInstructionTest.java
@@ -5,6 +5,7 @@
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,10 +23,15 @@ public class VoidInstructionTest {
         Screen screen = new Screen(1);
         Cassette cassette = new Cassette();
         regs = new RegisterSet();
-        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, null);
+        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, false);
         cpu = new CPU(io);
         extendedAddress = 0xC0A0;
         io.regs.pc.set(0);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/components/WordRegisterInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/WordRegisterInstructionTest.java
@@ -5,6 +5,7 @@
 package ca.craigthomas.yacoco3e.components;
 
 import ca.craigthomas.yacoco3e.datatypes.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,11 +24,16 @@ public class WordRegisterInstructionTest {
         Screen screen = new Screen(1);
         Cassette cassette = new Cassette();
         regs = new RegisterSet();
-        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, null);
+        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, false);
         cpu = new CPU(io);
         extendedAddress = 0xC0A0;
         address = new UnsignedWord(0xA000);
         io.regs.pc.set(0);
+    }
+
+    @After
+    public void tearDown() {
+        io.shutdown();
     }
 
     @Test(expected = MalformedInstructionException.class)

--- a/src/test/java/ca/craigthomas/yacoco3e/components/WordRegisterInstructionTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/WordRegisterInstructionTest.java
@@ -23,7 +23,7 @@ public class WordRegisterInstructionTest {
         Screen screen = new Screen(1);
         Cassette cassette = new Cassette();
         regs = new RegisterSet();
-        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette);
+        io = new IOController(new Memory(), regs, new EmulatedKeyboard(), screen, cassette, null);
         cpu = new CPU(io);
         extendedAddress = 0xC0A0;
         address = new UnsignedWord(0xA000);
@@ -40,27 +40,27 @@ public class WordRegisterInstructionTest {
     public void testStoreWordRegisterWorksCorrectly() {
         regs.s.set(0xBEEF);
         WordRegisterInstruction.storeWordRegister(io, regs.s, null, address, false);
-        assertEquals(0xBEEF, io.readWord(address).getInt());
+        assertEquals(0xBEEF, io.readWord(address).get());
 
         io.writeWord(address, 0);
         regs.u.set(0xBEEF);
         WordRegisterInstruction.storeWordRegister(io, regs.u, null, address, false);
-        assertEquals(0xBEEF, io.readWord(address).getInt());
+        assertEquals(0xBEEF, io.readWord(address).get());
 
         io.writeWord(address, 0);
         regs.y.set(0xBEEF);
         WordRegisterInstruction.storeWordRegister(io, regs.y, null, address, false);
-        assertEquals(0xBEEF, io.readWord(address).getInt());
+        assertEquals(0xBEEF, io.readWord(address).get());
 
         io.writeWord(address, 0);
         regs.x.set(new UnsignedWord(0xBEEF));
         WordRegisterInstruction.storeWordRegister(io, regs.x, null, address, false);
-        assertEquals(0xBEEF, io.readWord(address).getInt());
+        assertEquals(0xBEEF, io.readWord(address).get());
 
         io.writeWord(address, 0);
         regs.setD(0xBEEF);
         WordRegisterInstruction.storeWordRegister(io, regs.getD(), null, address, true);
-        assertEquals(0xBEEF, io.readWord(address).getInt());
+        assertEquals(0xBEEF, io.readWord(address).get());
     }
 
     @Test
@@ -95,7 +95,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(address, 0xA000);
         regs.s.set(0);
         WordRegisterInstruction.storeWordRegister(io, regs.s, null, address, false);
-        assertEquals(0, io.readWord(address).getInt());
+        assertEquals(0, io.readWord(address).get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
     }
@@ -104,7 +104,7 @@ public class WordRegisterInstructionTest {
     public void testStoreWordRegisterSetsNegative() {
         regs.s.set(0x8100);
         WordRegisterInstruction.storeWordRegister(io, regs.s, null, address, false);
-        assertEquals(0x8100, io.readWord(address).getInt());
+        assertEquals(0x8100, io.readWord(address).get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
     }
@@ -116,7 +116,7 @@ public class WordRegisterInstructionTest {
         regs.b.set(0xBB);
         io.writeWord(0x0000, 0xDD0A);
         cpu.executeInstruction();
-        assertEquals(0xAABB, io.readWord(0x000A).getInt());
+        assertEquals(0xAABB, io.readWord(0x000A).get());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class WordRegisterInstructionTest {
         regs.b.set(0xBB);
         io.writeWord(0x0000, 0xED80);
         cpu.executeInstruction();
-        assertEquals(0xAABB, io.readWord(extendedAddress).getInt());
+        assertEquals(0xAABB, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -136,7 +136,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0000, 0xFD);
         io.writeWord(0x0001, extendedAddress);
         cpu.executeInstruction();
-        assertEquals(0xAABB, io.readWord(extendedAddress).getInt());
+        assertEquals(0xAABB, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -144,7 +144,7 @@ public class WordRegisterInstructionTest {
         regs.u.set(0x1234);
         io.writeWord(0x0000, 0xDF0A);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(0x000A).getInt());
+        assertEquals(0x1234, io.readWord(0x000A).get());
     }
 
     @Test
@@ -153,7 +153,7 @@ public class WordRegisterInstructionTest {
         regs.x.set(extendedAddress);
         io.writeWord(0x0000, 0xEF80);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(extendedAddress).getInt());
+        assertEquals(0x1234, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -162,7 +162,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0000, 0xFF);
         io.writeWord(0x0001, extendedAddress);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(extendedAddress).getInt());
+        assertEquals(0x1234, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -170,7 +170,7 @@ public class WordRegisterInstructionTest {
         regs.x.set(0x1234);
         io.writeWord(0x0000, 0x9F0A);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(0x000A).getInt());
+        assertEquals(0x1234, io.readWord(0x000A).get());
     }
 
     @Test
@@ -179,7 +179,7 @@ public class WordRegisterInstructionTest {
         regs.y.set(extendedAddress);
         io.writeWord(0x0000, 0xAFA0);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(extendedAddress).getInt());
+        assertEquals(0x1234, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -188,7 +188,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0000, 0xBF);
         io.writeWord(0x0001, extendedAddress);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(extendedAddress).getInt());
+        assertEquals(0x1234, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -197,7 +197,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x109F);
         io.writeByte(0x0002, 0x0A);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(0x000A).getInt());
+        assertEquals(0x1234, io.readWord(0x000A).get());
     }
 
     @Test
@@ -207,7 +207,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x10AF);
         io.writeByte(0x0002, 0x80);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(extendedAddress).getInt());
+        assertEquals(0x1234, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -216,7 +216,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x10BF);
         io.writeWord(0x0002, extendedAddress);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(extendedAddress).getInt());
+        assertEquals(0x1234, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -225,7 +225,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x10DF);
         io.writeByte(0x0002, 0x0A);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(0x000A).getInt());
+        assertEquals(0x1234, io.readWord(0x000A).get());
     }
 
     @Test
@@ -235,7 +235,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x10EF);
         io.writeByte(0x0002, 0x80);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(extendedAddress).getInt());
+        assertEquals(0x1234, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -244,7 +244,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x10FF);
         io.writeWord(0x0002, extendedAddress);
         cpu.executeInstruction();
-        assertEquals(0x1234, io.readWord(extendedAddress).getInt());
+        assertEquals(0x1234, io.readWord(extendedAddress).get());
     }
 
     @Test
@@ -253,7 +253,7 @@ public class WordRegisterInstructionTest {
         regs.x.set(0x0020);
         io.writeByte(0, 0x3A);
         cpu.executeInstruction();
-        assertEquals(0x0028, regs.x.getInt());
+        assertEquals(0x0028, regs.x.get());
     }
 
     @Test
@@ -262,7 +262,7 @@ public class WordRegisterInstructionTest {
         regs.x.set(0x1091);
         io.writeByte(0x0000, 0x3A);
         cpu.executeInstruction();
-        assertEquals(0x10B2, regs.x.getInt());
+        assertEquals(0x10B2, regs.x.get());
     }
 
     @Test
@@ -271,9 +271,9 @@ public class WordRegisterInstructionTest {
         regs.b.set(0x0C);
         io.writeByte(0x0000, 0x3D);
         cpu.executeInstruction();
-        assertEquals(0x0384, regs.getD().getInt());
-        assertEquals(0x03, regs.a.getShort());
-        assertEquals(0x84, regs.b.getShort());
+        assertEquals(0x0384, regs.getD().get());
+        assertEquals(0x03, regs.a.get());
+        assertEquals(0x84, regs.b.get());
         assertFalse(regs.cc.isMasked(CC_N));
         assertFalse(regs.cc.isMasked(CC_Z));
         assertTrue(regs.cc.isMasked(CC_C));
@@ -294,7 +294,7 @@ public class WordRegisterInstructionTest {
     public void testLoadWordRegisterSetsZero() {
         io.regs.u.set(0xFFFF);
         WordRegisterInstruction.loadWordRegister(io, io.regs.u, new UnsignedWord(0x0000), null, false);
-        assertEquals(0, io.regs.u.getInt());
+        assertEquals(0, io.regs.u.get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
     }
@@ -303,7 +303,7 @@ public class WordRegisterInstructionTest {
     public void testLoadWordRegisterSetsNegative() {
         io.regs.u.set(0xFFFF);
         WordRegisterInstruction.loadWordRegister(io, io.regs.u, new UnsignedWord(0x8100), null, false);
-        assertEquals(0x8100, io.regs.u.getInt());
+        assertEquals(0x8100, io.regs.u.get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
     }
@@ -312,7 +312,7 @@ public class WordRegisterInstructionTest {
     public void testLoadWordRegisterSetsNegativeZero() {
         io.regs.u.set(0xFFFF);
         WordRegisterInstruction.loadWordRegister(io, io.regs.u, new UnsignedWord(0x8000), null, false);
-        assertEquals(0x8000, io.regs.u.getInt());
+        assertEquals(0x8000, io.regs.u.get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
     }
@@ -323,7 +323,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x10CE);
         io.writeWord(0x0002, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.s.getInt());
+        assertEquals(0xDDDD, regs.s.get());
     }
 
     @Test
@@ -333,7 +333,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0002, 0x0A);
         io.writeWord(0x000A, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.s.getInt());
+        assertEquals(0xDDDD, regs.s.get());
     }
 
     @Test
@@ -344,7 +344,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0002, 0x80);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.s.getInt());
+        assertEquals(0xDDDD, regs.s.get());
     }
 
     @Test
@@ -354,7 +354,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0002, extendedAddress);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.s.getInt());
+        assertEquals(0xDDDD, regs.s.get());
     }
 
     @Test
@@ -363,7 +363,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x108E);
         io.writeWord(0x0002, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.y.getInt());
+        assertEquals(0xDDDD, regs.y.get());
     }
 
     @Test
@@ -373,7 +373,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0002, 0x0A);
         io.writeWord(0x000A, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.y.getInt());
+        assertEquals(0xDDDD, regs.y.get());
     }
 
     @Test
@@ -384,7 +384,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0002, 0x80);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.y.getInt());
+        assertEquals(0xDDDD, regs.y.get());
     }
 
     @Test
@@ -394,7 +394,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0002, extendedAddress);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.y.getInt());
+        assertEquals(0xDDDD, regs.y.get());
     }
 
     @Test
@@ -403,7 +403,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0000, 0xCC);
         io.writeWord(0x0001, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.getD().getInt());
+        assertEquals(0xDDDD, regs.getD().get());
     }
 
     @Test
@@ -412,7 +412,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0xDC0A);
         io.writeWord(0x000A, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.getD().getInt());
+        assertEquals(0xDDDD, regs.getD().get());
     }
 
     @Test
@@ -422,7 +422,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0xEC80);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.getD().getInt());
+        assertEquals(0xDDDD, regs.getD().get());
     }
 
     @Test
@@ -432,7 +432,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0001, extendedAddress);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.getD().getInt());
+        assertEquals(0xDDDD, regs.getD().get());
     }
 
     @Test
@@ -441,7 +441,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0000, 0xCE);
         io.writeWord(0x0001, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.u.getInt());
+        assertEquals(0xDDDD, regs.u.get());
     }
 
     @Test
@@ -450,7 +450,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0xDE0A);
         io.writeWord(0x000A, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.u.getInt());
+        assertEquals(0xDDDD, regs.u.get());
     }
 
     @Test
@@ -460,7 +460,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0xEE80);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.u.getInt());
+        assertEquals(0xDDDD, regs.u.get());
     }
 
     @Test
@@ -470,7 +470,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0001, extendedAddress);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.u.getInt());
+        assertEquals(0xDDDD, regs.u.get());
     }
 
     @Test
@@ -479,7 +479,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0000, 0x8E);
         io.writeWord(0x0001, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.x.getInt());
+        assertEquals(0xDDDD, regs.x.get());
     }
 
     @Test
@@ -488,7 +488,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x9E0A);
         io.writeWord(0x000A, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.x.getInt());
+        assertEquals(0xDDDD, regs.x.get());
     }
 
     @Test
@@ -498,7 +498,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0xAEA0);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.x.getInt());
+        assertEquals(0xDDDD, regs.x.get());
     }
 
     @Test
@@ -508,7 +508,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0001, extendedAddress);
         io.writeWord(extendedAddress, 0xDDDD);
         cpu.executeInstruction();
-        assertEquals(0xDDDD, regs.x.getInt());
+        assertEquals(0xDDDD, regs.x.get());
     }
 
     @Test
@@ -561,7 +561,7 @@ public class WordRegisterInstructionTest {
     public void testCompareWordRegression1() {
         io.regs.u.set(0xFE00);
         WordRegisterInstruction.compareWord(io, io.regs.u, new UnsignedWord(0xF800), null, false);
-        assertEquals(0xFE00, io.regs.u.getInt());
+        assertEquals(0xFE00, io.regs.u.get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_C));
@@ -833,7 +833,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x30A0);
         io.writeWord(extendedAddress, 0x072E);
         cpu.executeInstruction();
-        assertEquals(extendedAddress, regs.x.getInt());
+        assertEquals(extendedAddress, regs.x.get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
     }
 
@@ -844,7 +844,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x3180);
         io.writeWord(extendedAddress, 0x072E);
         cpu.executeInstruction();
-        assertEquals(extendedAddress, regs.y.getInt());
+        assertEquals(extendedAddress, regs.y.get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
     }
 
@@ -855,7 +855,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x3180);
         io.writeWord(extendedAddress, 0x072E);
         cpu.executeInstruction();
-        assertEquals(0x0000, regs.y.getInt());
+        assertEquals(0x0000, regs.y.get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
     }
 
@@ -866,7 +866,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x3280);
         io.writeWord(extendedAddress, 0x072E);
         cpu.executeInstruction();
-        assertEquals(extendedAddress, regs.s.getInt());
+        assertEquals(extendedAddress, regs.s.get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
     }
 
@@ -877,14 +877,14 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x3380);
         io.writeWord(extendedAddress, 0x072E);
         cpu.executeInstruction();
-        assertEquals(extendedAddress, regs.u.getInt());
+        assertEquals(extendedAddress, regs.u.get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
     }
 
     @Test
     public void testAddWordWorksCorrectly() {
         WordRegisterInstruction.addWord(io, new UnsignedWord(0x0101), new UnsignedWord(0x0101), null, true);
-        assertEquals(0x0202, io.regs.getD().getInt());
+        assertEquals(0x0202, io.regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertFalse(io.regs.cc.isMasked(CC_V));
@@ -894,7 +894,7 @@ public class WordRegisterInstructionTest {
     @Test
     public void testAddWordSetsNegativeOverflow() {
         WordRegisterInstruction.addWord(io, new UnsignedWord(0x7FFF), new UnsignedWord(0x0001), null, true);
-        assertEquals(0x8000, io.regs.getD().getInt());
+        assertEquals(0x8000, io.regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_V));
@@ -904,7 +904,7 @@ public class WordRegisterInstructionTest {
     @Test
     public void testAddWordSetsZeroOverflowCarry() {
         WordRegisterInstruction.addWord(io, new UnsignedWord(0xFFFF), new UnsignedWord(0x0001), null, true);
-        assertEquals(0x0000, io.regs.getD().getInt());
+        assertEquals(0x0000, io.regs.getD().get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertFalse(io.regs.cc.isMasked(CC_V));
@@ -968,7 +968,7 @@ public class WordRegisterInstructionTest {
     @Test
     public void testSubtractDWorksSetsOverflow() {
         WordRegisterInstruction.subtractWord(io, new UnsignedWord(0x8000), new UnsignedWord(0x7FFF), null, true);
-        assertEquals(0x01, io.regs.getD().getInt());
+        assertEquals(0x01, io.regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_V));
@@ -978,7 +978,7 @@ public class WordRegisterInstructionTest {
     @Test
     public void testSubtractDWorksSetsCarry() {
         WordRegisterInstruction.subtractWord(io, new UnsignedWord(0x7FFF), new UnsignedWord(0x8000), null, true);
-        assertEquals(0xFFFF, io.regs.getD().getInt());
+        assertEquals(0xFFFF, io.regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_V));
@@ -988,7 +988,7 @@ public class WordRegisterInstructionTest {
     @Test
     public void testSubtractDWorksCorrectly() {
         WordRegisterInstruction.subtractWord(io, new UnsignedWord(0x6A00), new UnsignedWord(0x2700), null, true);
-        assertEquals(0x4300, io.regs.getD().getInt());
+        assertEquals(0x4300, io.regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertFalse(io.regs.cc.isMasked(CC_V));
@@ -998,7 +998,7 @@ public class WordRegisterInstructionTest {
     @Test
     public void testSubtractDWorksSetsZero() {
         WordRegisterInstruction.subtractWord(io, new UnsignedWord(0x0001), new UnsignedWord(0x0001), null, true);
-        assertEquals(0x0000, io.regs.getD().getInt());
+        assertEquals(0x0000, io.regs.getD().get());
         assertTrue(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertFalse(io.regs.cc.isMasked(CC_V));
@@ -1008,7 +1008,7 @@ public class WordRegisterInstructionTest {
     @Test
     public void testSubtractDWorksSetsNegativeSetsCarry() {
         WordRegisterInstruction.subtractWord(io, new UnsignedWord(0x8000), new UnsignedWord(0x8001), null, true);
-        assertEquals(0xFFFF, io.regs.getD().getInt());
+        assertEquals(0xFFFF, io.regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertTrue(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_C));
@@ -1018,7 +1018,7 @@ public class WordRegisterInstructionTest {
     @Test
     public void testSubtractDRegression1() {
         WordRegisterInstruction.subtractWord(io, new UnsignedWord(0xFE00), new UnsignedWord(0xF800), null, true);
-        assertEquals(0x0600, regs.getD().getInt());
+        assertEquals(0x0600, regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_V));
         assertFalse(io.regs.cc.isMasked(CC_C));
@@ -1031,7 +1031,7 @@ public class WordRegisterInstructionTest {
         io.writeByte(0x0000, 0x83);
         io.writeWord(0x0001, 0x7FFF);
         cpu.executeInstruction();
-        assertEquals(0x01, regs.getD().getInt());
+        assertEquals(0x01, regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_V));
@@ -1045,7 +1045,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0x9301);
         io.writeWord(0x1001, 0x7FFF);
         cpu.executeInstruction();
-        assertEquals(0x01, regs.getD().getInt());
+        assertEquals(0x01, regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_V));
@@ -1059,7 +1059,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0000, 0xA380);
         io.writeWord(extendedAddress, 0x7FFF);
         cpu.executeInstruction();
-        assertEquals(0x01, regs.getD().getInt());
+        assertEquals(0x01, regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_V));
@@ -1073,7 +1073,7 @@ public class WordRegisterInstructionTest {
         io.writeWord(0x0001, extendedAddress);
         io.writeWord(extendedAddress, 0x7FFF);
         cpu.executeInstruction();
-        assertEquals(0x01, regs.getD().getInt());
+        assertEquals(0x01, regs.getD().get());
         assertFalse(io.regs.cc.isMasked(CC_Z));
         assertFalse(io.regs.cc.isMasked(CC_N));
         assertTrue(io.regs.cc.isMasked(CC_V));

--- a/src/test/java/ca/craigthomas/yacoco3e/datatypes/UnsignedByteTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/datatypes/UnsignedByteTest.java
@@ -13,25 +13,25 @@ public class UnsignedByteTest
     @Test
     public void testShortValueOnlyContains8Bits() {
         UnsignedByte result = new UnsignedByte(0xFFFF);
-        assertEquals(0xFF, result.getShort());
+        assertEquals(0xFF, result.get());
     }
 
     @Test
     public void testTwosComplimentZero() {
         UnsignedByte result = new UnsignedByte(0);
-        assertEquals(0, result.twosCompliment().getShort());
+        assertEquals(0, result.twosCompliment().get());
     }
 
     @Test
     public void testTwosComplimentOne() {
         UnsignedByte result = new UnsignedByte(1);
-        assertEquals(0xFF, result.twosCompliment().getShort());
+        assertEquals(0xFF, result.twosCompliment().get());
     }
 
     @Test
     public void testTwosComplimentTwo() {
         UnsignedByte result = new UnsignedByte(2);
-        assertEquals(0xFE, result.twosCompliment().getShort());
+        assertEquals(0xFE, result.twosCompliment().get());
     }
 
     @Test
@@ -167,18 +167,18 @@ public class UnsignedByteTest
     }
 
     @Test
-    public void testGetSignedShortWorksCorrectly() {
+    public void testGetSignedWorksCorrectly() {
         UnsignedByte result = new UnsignedByte(0x40);
-        assertEquals(0x40, result.getSignedShort());
+        assertEquals(0x40, result.getSigned());
 
         result = new UnsignedByte(0xFF);
-        assertEquals(-1, result.getSignedShort());
+        assertEquals(-1, result.getSigned());
     }
 
     @Test
     public void testInverseWorksCorrectly() {
         UnsignedByte result = new UnsignedByte(0xFF);
-        assertEquals(0x0, result.inverse().getShort());
+        assertEquals(0x0, result.inverse().get());
     }
 
     @Test

--- a/src/test/java/ca/craigthomas/yacoco3e/datatypes/UnsignedWordTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/datatypes/UnsignedWordTest.java
@@ -13,45 +13,45 @@ public class UnsignedWordTest
     @Test
     public void testValuePreserved() {
         UnsignedWord result = new UnsignedWord(0xFFFF);
-        assertEquals(0xFFFF, result.getInt());
+        assertEquals(0xFFFF, result.get());
     }
 
     @Test
     public void testNextLowValue() {
         UnsignedWord result = new UnsignedWord(0x0001);
-        assertEquals(0x0002, result.next().getInt());
+        assertEquals(0x0002, result.next().get());
     }
 
     @Test
     public void testNextRollsOver() {
         UnsignedWord result = new UnsignedWord(0xFFFF);
-        assertEquals(0x0000, result.next().getInt());
+        assertEquals(0x0000, result.next().get());
     }
 
     @Test
     public void testDefaultConstructorSetsZero() {
         UnsignedWord result = new UnsignedWord();
-        assertEquals(0, result.getInt());
+        assertEquals(0, result.get());
     }
 
     @Test
     public void testAlternateConstructor() {
         UnsignedWord result = new UnsignedWord(0xC0, new UnsignedByte(0x11));
-        assertEquals(0xC011, result.getInt());
+        assertEquals(0xC011, result.get());
     }
 
     @Test
     public void testHighSetsHighByteOnly() {
         UnsignedWord result = new UnsignedWord();
         result.setHigh(new UnsignedByte(0xFF));
-        assertEquals(0xFF00, result.getInt());
+        assertEquals(0xFF00, result.get());
     }
 
     @Test
     public void testLowSetsLowByteOnly() {
         UnsignedWord result = new UnsignedWord();
         result.setLow(new UnsignedByte(0xFF));
-        assertEquals(0x00FF, result.getInt());
+        assertEquals(0x00FF, result.get());
     }
 
     @Test
@@ -108,12 +108,12 @@ public class UnsignedWordTest
     public void testORMaskWorksCorrectly() {
         UnsignedWord word1 = new UnsignedWord(0x2);
         word1.or(0x1);
-        assertEquals(0x3, word1.getInt());
+        assertEquals(0x3, word1.get());
     }
 
     @Test
     public void testInverseWorksCorrectly() {
         UnsignedWord word1 = new UnsignedWord(0xFFFF);
-        assertEquals(0x0, word1.inverse().getInt());
+        assertEquals(0x0, word1.inverse().get());
     }
 }


### PR DESCRIPTION
This PR implements the device selector as controlled by the two PIAs in the system. The PIA code was also refactored so that they are now individual objects, instead of being represented by multiple unsigned byte objects. Also added was a digital analog converter, although the current audio system implementation does not correctly produce sounds due to buffering issues. Several CPU condition code register fixes were implemented across several different instructions. Unsigned bytes and words were cleaned up to create simple `get` methods instead of `getShort`. The VDG code was also updated, fixing several bugs with setting screen resolutions. Unit tests were refactored where existing code was changed. New code added has little test coverage. Merging this in as it has become too large and unfocused.