### PR TITLE
Gime advanced mode stubs

### DIFF
--- a/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
+++ b/src/main/java/ca/craigthomas/yacoco3e/components/IOController.java
@@ -973,9 +973,9 @@ public class IOController
     public void updateVerticalOffset() {
         int newOffset = 0;
         if (lowResolutionDisplayActive) {
-            newOffset = ((verticalOffsetRegister1.get() & 0xE0) >> 1) << 16;
-            newOffset += (samDisplayOffsetRegister.get() & 0x7F) << 10;
-            newOffset += (verticalOffsetRegister0.get() & 0x1F) << 3;
+            newOffset = ((verticalOffsetRegister1.get() & 0xE0) >> 5) << 16;
+            newOffset += (samDisplayOffsetRegister.get() & 0x7F) << 9;
+            newOffset += (verticalOffsetRegister0.get() & 0x3F) << 3;
         } else {
             newOffset = verticalOffsetRegister1.get() << 11;
             newOffset += verticalOffsetRegister0.get() << 3;
@@ -1149,27 +1149,15 @@ public class IOController
      * @return the register
      */
     public UnsignedWord getWordRegister(Register register) {
-        switch (register) {
-            case Y:
-                return regs.y;
-
-            case X:
-                return regs.x;
-
-            case S:
-                return regs.s;
-
-            case U:
-                return regs.u;
-
-            case D:
-                return regs.getD();
-
-            case PC:
-                return regs.pc;
-        }
-
-        return null;
+        return switch (register) {
+            case Y -> regs.y;
+            case X -> regs.x;
+            case S -> regs.s;
+            case U -> regs.u;
+            case D -> regs.getD();
+            case PC -> regs.pc;
+            default -> null;
+        };
     }
 
     /**
@@ -1183,22 +1171,13 @@ public class IOController
         value &= 0x60;
         value = value >> 5;
 
-        switch (value) {
-            case 0x0:
-                return Register.X;
-
-            case 0x1:
-                return Register.Y;
-
-            case 0x2:
-                return Register.U;
-
-            case 0x3:
-                return Register.S;
-
-            default:
-                return Register.UNKNOWN;
-        }
+        return switch (value) {
+            case 0x0 -> Register.X;
+            case 0x1 -> Register.Y;
+            case 0x2 -> Register.U;
+            case 0x3 -> Register.S;
+            default -> Register.UNKNOWN;
+        };
     }
 
     /**

--- a/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
@@ -232,7 +232,7 @@ public class IOControllerTest
 
     @Test
     public void testUpdateVerticalOffsetCoCoCompatibleWorksCorrectly() {
-        io.cocoCompatibleMode = true;
+        io.lowResolutionDisplayActive = true;
         io.verticalOffsetRegister = new UnsignedWord(0x0402);
         io.samDisplayOffsetRegister = new UnsignedByte(0x20);
         io.updateVerticalOffset();

--- a/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
+++ b/src/test/java/ca/craigthomas/yacoco3e/components/IOControllerTest.java
@@ -121,15 +121,15 @@ public class IOControllerTest
     public void testVerticalOffsetRegister1SetCorrectly() {
         io.writeByte(new UnsignedWord(0xFF9D), new UnsignedByte(0xFA));
         assertEquals(new UnsignedByte(0xFA), io.readByte(new UnsignedWord(0xFF9D)));
-        assertEquals(new UnsignedWord(0xFA00), io.verticalOffsetRegister);
+        assertEquals(new UnsignedByte(0xFA), io.verticalOffsetRegister1);
     }
 
     @Test
     public void testVerticalOffsetRegister0SetCorrectly() {
-        io.verticalOffsetRegister = new UnsignedWord(0);
+        io.verticalOffsetRegister0 = new UnsignedByte(0);
         io.writeByte(new UnsignedWord(0xFF9E), new UnsignedByte(0xFA));
         assertEquals(new UnsignedByte(0xFA), io.readByte(new UnsignedWord(0xFF9E)));
-        assertEquals(new UnsignedWord(0x00FA), io.verticalOffsetRegister);
+        assertEquals(new UnsignedByte(0xFA), io.verticalOffsetRegister0);
     }
 
     @Test
@@ -233,10 +233,31 @@ public class IOControllerTest
     @Test
     public void testUpdateVerticalOffsetCoCoCompatibleWorksCorrectly() {
         io.lowResolutionDisplayActive = true;
-        io.verticalOffsetRegister = new UnsignedWord(0x0402);
-        io.samDisplayOffsetRegister = new UnsignedByte(0x20);
+        io.verticalOffsetRegister1 = new UnsignedByte(0xA0);
+        io.verticalOffsetRegister0 = new UnsignedByte(0x2A);
+        io.samDisplayOffsetRegister = new UnsignedByte(0x55);
         io.updateVerticalOffset();
-        assertEquals(16392, screen.getMemoryOffset());
+        assertEquals(371536, screen.getMemoryOffset());
+    }
+
+    @Test
+    public void testUpdateVerticalOffsetCoCoCompatibleWorksCorrectly1() {
+        io.lowResolutionDisplayActive = true;
+        io.verticalOffsetRegister1 = new UnsignedByte(0xff);
+        io.verticalOffsetRegister0 = new UnsignedByte(0xff);
+        io.samDisplayOffsetRegister = new UnsignedByte(0xff);
+        io.updateVerticalOffset();
+        assertEquals(524280, screen.getMemoryOffset());
+    }
+
+    @Test
+    public void testUpdateVerticalOffsetCoCoCompatibleWorksCorrectly2() {
+        io.lowResolutionDisplayActive = true;
+        io.verticalOffsetRegister1 = new UnsignedByte(0xE0);
+        io.verticalOffsetRegister0 = new UnsignedByte(0x3F);
+        io.samDisplayOffsetRegister = new UnsignedByte(0x7F);
+        io.updateVerticalOffset();
+        assertEquals(524280, screen.getMemoryOffset());
     }
 
     @Test


### PR DESCRIPTION
This PR begins to add variables necessary to implement the CoCo 3 advanced graphics modes (those outside of the ones provided by the CoCo 1/2). Variables are added to control the border color, and the offset resolution register was updated to be in line with the concept of 2 registers to control where in video memory the offset should begin. The offset calculation was also updated and simplified to use shifting instead of heavier multiplication instructions. Unit tests updated to reflect changes to existing functionality.
